### PR TITLE
Added Rds discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Magpie supports AWS as a core plugin out of the box. Checked boxes are complete 
 - [ ] Lambda
 - [ ] Lightsail
 - [ ] QLDB
-- [ ] RDS
+- [x] RDS
 - [ ] Redshift
 - [ ] Route 53
 - [ ] Secrets Manager

--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -44,6 +44,11 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>rds</artifactId>
+      <version>${aws.sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>cloudwatch</artifactId>
       <version>${aws.sdk.version}</version>
     </dependency>

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryPlugin.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryPlugin.java
@@ -19,10 +19,11 @@ package io.openraven.magpie.plugins.aws.discovery;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.openraven.magpie.plugins.aws.discovery.services.AWSDiscovery;
-import io.openraven.magpie.plugins.aws.discovery.services.EC2Discovery;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.OriginPlugin;
 import io.openraven.magpie.api.Session;
+import io.openraven.magpie.plugins.aws.discovery.services.EC2Discovery;
+import io.openraven.magpie.plugins.aws.discovery.services.RdsDiscovery;
 import io.openraven.magpie.plugins.aws.discovery.services.S3Discovery;
 import org.slf4j.Logger;
 import software.amazon.awssdk.regions.Region;
@@ -38,7 +39,7 @@ public class AWSDiscoveryPlugin implements OriginPlugin<AWSDiscoveryConfig> {
 
   public final static String ID = "magpie.aws.discovery";
 
-  private static final List<AWSDiscovery> DISCOVERY_LIST = List.of(new EC2Discovery(), new S3Discovery());
+  private static final List<AWSDiscovery> DISCOVERY_LIST = List.of(new EC2Discovery(), new S3Discovery(), new RdsDiscovery());
 
   private Logger logger;
   private AWSDiscoveryConfig config;

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSUtils.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSUtils.java
@@ -135,6 +135,15 @@ public class AWSUtils {
     return payload;
   }
 
+  public static Pair<Long, GetMetricStatisticsResponse> getCloudwatchMetricMinimum(
+    String regionID, String namespace, String metric, List<Dimension> dimensions) {
+
+    GetMetricStatisticsResponse getMetricStatisticsResult = getCloudwatchMetricStatistics(regionID, namespace, metric, Statistic.MINIMUM, dimensions);
+
+    return Pair.with(getMetricStatisticsResult.datapoints().stream().map(Datapoint::maximum)
+      .map(Double::longValue).max(Long::compareTo).orElse(null), getMetricStatisticsResult);
+  }
+
   public static Pair<Long, GetMetricStatisticsResponse> getCloudwatchMetricMaximum(
     String regionID, String namespace, String metric, List<Dimension> dimensions) {
 

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/Conversions.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/Conversions.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Open Raven Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.openraven.magpie.plugins.aws.discovery;
+
+public class Conversions {
+  public static long GibToBytes(long gib) {
+    return gib * 1074000000L;
+  }
+}

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/RdsDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/RdsDiscovery.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2021 Open Raven Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.api.Session;
+import io.openraven.magpie.plugins.aws.discovery.AWSDiscoveryPlugin;
+import io.openraven.magpie.plugins.aws.discovery.AWSUtils;
+import io.openraven.magpie.plugins.aws.discovery.Conversions;
+import org.javatuples.Pair;
+import org.slf4j.Logger;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsResponse;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
+import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.rds.model.Tag;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.openraven.magpie.plugins.aws.discovery.AWSUtils.getAwsResponse;
+import static java.util.Arrays.asList;
+
+public class RdsDiscovery implements AWSDiscovery {
+  private final List<LocalDiscovery> discoveryMethods = asList(
+    this::discoverTags,
+    this::discoverDbClusters,
+    this::discoverSize
+  );
+
+  @FunctionalInterface
+  interface LocalDiscovery {
+    void discover(RdsClient client, DBInstance resource, ObjectNode data, Logger logger, ObjectMapper mapper);
+  }
+
+  @Override
+  public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger) {
+    logger.info("Discovering RDS instances in {}", region);
+    final var client = RdsClient.builder().region(region).build();
+
+    try {
+      client.describeDBInstancesPaginator().dbInstances().stream()
+        .forEach(db -> {
+          var data = mapper.createObjectNode();
+          data.put("region", region.toString());
+
+          if (db.instanceCreateTime() == null) {
+            logger.warn("DBInstance has NULL CreateTime: dbInstanceArn=\"{}\"", db.dbInstanceArn());
+          }
+
+
+          for (var dm : discoveryMethods) {
+            try {
+              dm.discover(client, db, data, logger, mapper);
+            } catch (SdkServiceException | SdkClientException ex) {
+              logger.error("Failed to discover data for {}", db.dbName(), ex);
+            }
+          }
+
+          emitter.emit(new MagpieEnvelope(session, List.of(AWSDiscoveryPlugin.ID + ":Rds"), data));
+        });
+    } catch (SdkServiceException | SdkClientException ex) {
+      logger.error("Finished Rds bucket discovery in {}", region);
+    }
+
+    logger.info("Finished Rds instances discovery in {}", region);
+  }
+
+  private void discoverTags(RdsClient client, DBInstance resource, ObjectNode data, Logger logger, ObjectMapper mapper) {
+    logger.info("Getting tags for {}", resource.dbName());
+    var obj = data.putObject("tags");
+    getAwsResponse(
+      () -> client.listTagsForResource(ListTagsForResourceRequest.builder().resourceName(resource.dbInstanceArn()).build()),
+      (resp) -> {
+        JsonNode tagsNode = mapper.convertValue(resp.tagList().stream()
+          .collect(Collectors.toMap(Tag::key, Tag::value)), JsonNode.class);
+        AWSUtils.update(obj, tagsNode);
+      },
+      (noresp) -> AWSUtils.update(obj, noresp)
+    );
+  }
+
+  private void discoverDbClusters(RdsClient client, DBInstance resource, ObjectNode data, Logger logger, ObjectMapper mapper) {
+    logger.info("Getting DbClusters for {}", resource.dbInstanceArn());
+    final String keyname = "DbClusters";
+    getAwsResponse(
+      () -> client.describeDBClusters(DescribeDbClustersRequest.builder().dbClusterIdentifier(resource.dbClusterIdentifier()).build()),
+      (resp) -> AWSUtils.update(data, Map.of(keyname, resp)),
+      (noresp) -> AWSUtils.update(data, Map.of(keyname, noresp))
+    );
+  }
+
+  private void discoverSize(RdsClient client, DBInstance resource, ObjectNode data, Logger logger, ObjectMapper mapper) {
+    logger.info("Getting DBSize for {}", resource.dbInstanceArn());
+    // get the DB engine and call the relevant function (as although RDS uses same client, the metrics available are different)
+    String engine = resource.engine();
+    if (engine != null) {
+      if ("docdb".equalsIgnoreCase(engine)) {
+        // although DocDB uses RDS client, it's metrics are subtly different, so get metrics via setDocDBSize
+        setDocDBSize(resource, data, logger);
+      } else if (engine.startsWith("aurora")) {
+        setAuroraDBSize(resource, data, logger);
+      } else {
+        setRDSSize(resource, data, logger);
+      }
+    } else {
+      logger.warn("{} RDS instance is missing engine property", resource.dbInstanceIdentifier());
+    }
+  }
+
+  private void setRDSSize(DBInstance resource, ObjectNode data, Logger logger) {
+    try {
+      List<Dimension> dimensions = new ArrayList<>();
+      dimensions.add(Dimension.builder().name("DBInstanceIdentifier").value(resource.dbInstanceIdentifier()).build());
+      Pair<Long, GetMetricStatisticsResponse> freeStorageSpace =
+        AWSUtils.getCloudwatchMetricMinimum(data.get("region").asText(), "AWS/RDS", "FreeStorageSpace", dimensions);
+
+      if (freeStorageSpace.getValue0() != null) {
+        logger.warn("{} RDS instance is missing engine property", resource.dbInstanceIdentifier());
+        AWSUtils.update(data, Map.of("size", Map.of("FreeStorageSpace", freeStorageSpace.getValue0())));
+
+        // pull the relevant node(s) from the payload object. See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html
+        long freeStorageCapacity = freeStorageSpace.getValue0();
+        long storageCapacity = resource.allocatedStorage();
+
+        data.put("sizeInBytes", Conversions.GibToBytes(storageCapacity) - freeStorageCapacity);
+        data.put("maxSizeInBytes", Conversions.GibToBytes(storageCapacity));
+      } else {
+        logger.warn("{} RDS instance is missing size metrics", resource.dbInstanceIdentifier());
+      }
+    } catch (Exception se) {
+      logger.warn("{} Rds instance is missing size metrics, with error {}", resource.dbInstanceIdentifier(), se.getMessage());
+    }
+  }
+
+  private void setDocDBSize(DBInstance resource, ObjectNode data, Logger logger) {
+    try {
+      List<Dimension> dimensions = new ArrayList<>();
+      dimensions.add(Dimension.builder().name("DBClusterIdentifier").value(resource.dbInstanceIdentifier()).build());
+      Pair<Long, GetMetricStatisticsResponse> volumeBytesUsed =
+        AWSUtils.getCloudwatchMetricMaximum(data.get("region").asText(), "AWS/DocDB", "VolumeBytesUsed", dimensions);
+
+      if (volumeBytesUsed.getValue0() != null) {
+          AWSUtils.update(data, Map.of("size", Map.of("VolumeBytesUsed", volumeBytesUsed.getValue0())));
+
+        data.put("sizeInBytes", volumeBytesUsed.getValue0());
+        data.put("maxSizeInBytes", Conversions.GibToBytes(resource.allocatedStorage()));
+      }
+    } catch (Exception se) {
+      logger.warn("{} RDS instance is missing size metrics, with error {}", resource.dbName(), se.getMessage());
+    }
+  }
+
+  private void setAuroraDBSize(DBInstance resource, ObjectNode data, Logger logger) {
+    try {
+      List<Dimension> dimensions = new ArrayList<>();
+      dimensions.add(Dimension.builder().name("DBClusterIdentifier").value(resource.dbInstanceIdentifier()).build());
+      Pair<Long, GetMetricStatisticsResponse> volumeBytesUsed =
+        AWSUtils.getCloudwatchMetricMaximum(data.get("region").asText(), "AWS/RDS", "VolumeBytesUsed", dimensions);
+
+      if (volumeBytesUsed.getValue0() != null) {
+        AWSUtils.update(data, Map.of("size", Map.of("VolumeBytesUsed", volumeBytesUsed.getValue0())));
+
+        data.put("sizeInBytes", volumeBytesUsed.getValue0());
+        data.put("maxSizeInBytes", Conversions.GibToBytes(resource.allocatedStorage()));
+
+      }
+    } catch (Exception se) {
+      logger.warn("{} RDS instance is missing size metrics, with error {}", resource.dbName(), se.getMessage());
+    }
+  }
+}

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/RdsDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/RdsDiscovery.java
@@ -83,7 +83,7 @@ public class RdsDiscovery implements AWSDiscovery {
             }
           }
 
-          emitter.emit(new MagpieEnvelope(session, List.of(AWSDiscoveryPlugin.ID + ":Rds"), data));
+          emitter.emit(new MagpieEnvelope(session, List.of(AWSDiscoveryPlugin.ID + ":rds"), data));
         });
     } catch (SdkServiceException | SdkClientException ex) {
       logger.error("Finished Rds bucket discovery in {}", region);


### PR DESCRIPTION
Addresses https://github.com/openraven/magpie/issues/2

```
16:38:59.472 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in eu-north-1
16:39:00.004 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in eu-north-1
16:39:00.004 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in ap-south-1
16:39:00.751 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in ap-south-1
16:39:00.752 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in eu-west-3
16:39:01.051 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in eu-west-3
16:39:01.051 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in eu-west-2
16:39:01.372 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in eu-west-2
16:39:01.372 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in eu-west-1
16:39:01.874 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in eu-west-1
16:39:01.874 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in ap-northeast-3
16:39:03.167 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in ap-northeast-3
16:39:03.167 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in ap-northeast-2
16:39:04.602 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in ap-northeast-2
16:39:04.602 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in ap-northeast-1
16:39:06.204 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in ap-northeast-1
16:39:06.204 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in sa-east-1
16:39:07.563 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in sa-east-1
16:39:07.564 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in ca-central-1
16:39:08.305 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in ca-central-1
16:39:08.306 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in ap-southeast-1
16:39:09.538 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in ap-southeast-1
16:39:09.539 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in ap-southeast-2
16:39:10.915 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in ap-southeast-2
16:39:10.915 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in eu-central-1
16:39:11.164 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in eu-central-1
16:39:11.164 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in us-east-1
16:39:11.991 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Getting tags for null
16:39:12.189 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Getting DbClusters for arn:aws:rds:us-east-1:321859670049:db:docdb-2020-06-12-17-05-48
16:39:12.547 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Getting DBSize for arn:aws:rds:us-east-1:321859670049:db:docdb-2020-06-12-17-05-48
16:39:13.433 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in us-east-1
16:39:13.433 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in us-east-2
{
  "session" : {
    "id" : "60bf8e84-b8bf-41d5-a508-a92a56e566da",
    "createdAt" : "2021-03-23T15:38:57.266465Z"
  },
  "pluginPath" : [ "magpie.aws.discovery:Rds" ],
  "contents" : {
    "region" : "us-east-1",
    "tags" : { },
    "DbClusters" : {
      "marker" : null,
      "dbClusters" : [ {
        "allocatedStorage" : 1,
        "availabilityZones" : [ "us-east-1f", "us-east-1b", "us-east-1d" ],
        "backupRetentionPeriod" : 1,
        "characterSetName" : null,
        "databaseName" : null,
        "dbClusterIdentifier" : "docdb-2020-06-12-17-05-48",
        "dbClusterParameterGroup" : "default.docdb3.6",
        "dbSubnetGroup" : "default",
        "status" : "available",
        "percentProgress" : null,
        "earliestRestorableTime" : "2021-03-22T00:14:22.655Z",
        "endpoint" : "docdb-2020-06-12-17-05-48.cluster-cziutqdayzm4.us-east-1.docdb.amazonaws.com",
        "readerEndpoint" : "docdb-2020-06-12-17-05-48.cluster-ro-cziutqdayzm4.us-east-1.docdb.amazonaws.com",
        "customEndpoints" : null,
        "multiAZ" : false,
        "engine" : "docdb",
        "engineVersion" : "3.6.0",
        "latestRestorableTime" : "2021-03-23T15:35:26.780Z",
        "port" : 27017,
        "masterUsername" : "dbadmin",
        "dbClusterOptionGroupMemberships" : null,
        "preferredBackupWindow" : "00:00-00:30",
        "preferredMaintenanceWindow" : "tue:03:34-tue:04:04",
        "replicationSourceIdentifier" : null,
        "readReplicaIdentifiers" : [ ],
        "dbClusterMembers" : [ {
          "dbInstanceIdentifier" : "docdb-2020-06-12-17-05-48",
          "isClusterWriter" : true,
          "dbClusterParameterGroupStatus" : "in-sync",
          "promotionTier" : 1
        } ],
        "vpcSecurityGroups" : [ {
          "vpcSecurityGroupId" : "sg-706c4359",
          "status" : "active"
        } ],
        "hostedZoneId" : "ZNKXH85TT8WVW",
        "storageEncrypted" : true,
        "kmsKeyId" : "arn:aws:kms:us-east-1:321859670049:key/f8722a45-e1f2-4cb5-a566-f3a4f51457ed",
        "dbClusterResourceId" : "cluster-PYVVEHLR7KATFL77TK4TT22PZI",
        "dbClusterArn" : "arn:aws:rds:us-east-1:321859670049:cluster:docdb-2020-06-12-17-05-48",
        "associatedRoles" : [ ],
        "iamDatabaseAuthenticationEnabled" : false,
        "cloneGroupId" : null,
        "clusterCreateTime" : "2020-06-12T17:06:36.365Z",
        "earliestBacktrackTime" : null,
        "backtrackWindow" : null,
        "backtrackConsumedChangeRecords" : null,
        "enabledCloudwatchLogsExports" : null,
        "capacity" : null,
        "engineMode" : "provisioned",
        "scalingConfigurationInfo" : null,
        "deletionProtection" : false,
        "httpEndpointEnabled" : false,
        "activityStreamMode" : null,
        "activityStreamStatus" : "stopped",
        "activityStreamKmsKeyId" : null,
        "activityStreamKinesisStreamName" : null,
        "copyTagsToSnapshot" : false,
        "crossAccountClone" : false,
        "domainMemberships" : [ ],
        "tagList" : [ ],
        "globalWriteForwardingStatus" : null,
        "globalWriteForwardingRequested" : null,
        "pendingModifiedValues" : null
      } ]
    },
    "size" : {
      "VolumeBytesUsed" : 49954816
    },
    "sizeInBytes" : 49954816,
    "maxSizeInBytes" : 1074000000
  },
  "contentClass" : "com.fasterxml.jackson.databind.node.ObjectNode"
}
16:39:14.147 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in us-east-2
16:39:14.148 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in us-west-1
16:39:15.054 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in us-west-1
16:39:15.054 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Discovering RDS instances in us-west-2
16:39:16.142 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Getting tags for null
16:39:16.455 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Getting DbClusters for arn:aws:rds:us-west-2:321859670049:db:neptunedb-instance-1
16:39:16.765 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Getting DBSize for arn:aws:rds:us-west-2:321859670049:db:neptunedb-instance-1
16:39:17.708 [pool-1-thread-1] WARN  i.o.m.p.a.d.AWSDiscoveryPlugin - neptunedb-instance-1 RDS instance is missing size metrics
16:39:17.708 [pool-1-thread-1] INFO  i.o.m.p.a.d.AWSDiscoveryPlugin - Finished Rds instances discovery in us-west-2
{
  "session" : {
    "id" : "60bf8e84-b8bf-41d5-a508-a92a56e566da",
    "createdAt" : "2021-03-23T15:38:57.266465Z"
  },
  "pluginPath" : [ "magpie.aws.discovery:Rds" ],
  "contents" : {
    "region" : "us-west-2",
    "tags" : { },
    "DbClusters" : {
      "marker" : null,
      "dbClusters" : [ {
        "allocatedStorage" : 1,
        "availabilityZones" : [ "us-west-2c", "us-west-2b", "us-west-2d" ],
        "backupRetentionPeriod" : 1,
        "characterSetName" : null,
        "databaseName" : null,
        "dbClusterIdentifier" : "neptunedb",
        "dbClusterParameterGroup" : "default.neptune1",
        "dbSubnetGroup" : "default-vpc-08cc5635964d1f41f",
        "status" : "available",
        "percentProgress" : null,
        "earliestRestorableTime" : "2021-03-22T10:44:28.247Z",
        "endpoint" : "neptunedb.cluster-csuzxmfx5ngc.us-west-2.neptune.amazonaws.com",
        "readerEndpoint" : "neptunedb.cluster-ro-csuzxmfx5ngc.us-west-2.neptune.amazonaws.com",
        "customEndpoints" : null,
        "multiAZ" : false,
        "engine" : "neptune",
        "engineVersion" : "1.0.4.0",
        "latestRestorableTime" : "2021-03-23T15:37:33.922Z",
        "port" : 8182,
        "masterUsername" : "admin",
        "dbClusterOptionGroupMemberships" : null,
        "preferredBackupWindow" : "10:35-11:05",
        "preferredMaintenanceWindow" : "mon:07:37-mon:08:07",
        "replicationSourceIdentifier" : null,
        "readReplicaIdentifiers" : [ ],
        "dbClusterMembers" : [ {
          "dbInstanceIdentifier" : "neptunedb-instance-1",
          "isClusterWriter" : true,
          "dbClusterParameterGroupStatus" : "in-sync",
          "promotionTier" : 1
        } ],
        "vpcSecurityGroups" : [ {
          "vpcSecurityGroupId" : "sg-04ee86fc5944dd022",
          "status" : "active"
        } ],
        "hostedZoneId" : "Z22EZDAJT6W257",
        "storageEncrypted" : true,
        "kmsKeyId" : "arn:aws:kms:us-west-2:321859670049:key/7142cbed-82a1-4625-92ad-28175217dd4d",
        "dbClusterResourceId" : "cluster-U2LDD263ABRJFAOP666YEIWTVU",
        "dbClusterArn" : "arn:aws:rds:us-west-2:321859670049:cluster:neptunedb",
        "associatedRoles" : [ ],
        "iamDatabaseAuthenticationEnabled" : false,
        "cloneGroupId" : null,
        "clusterCreateTime" : "2020-11-11T01:06:02.554Z",
        "earliestBacktrackTime" : null,
        "backtrackWindow" : null,
        "backtrackConsumedChangeRecords" : null,
        "enabledCloudwatchLogsExports" : null,
        "capacity" : null,
        "engineMode" : "provisioned",
        "scalingConfigurationInfo" : null,
        "deletionProtection" : false,
        "httpEndpointEnabled" : false,
        "activityStreamMode" : null,
        "activityStreamStatus" : "stopped",
        "activityStreamKmsKeyId" : null,
        "activityStreamKinesisStreamName" : null,
        "copyTagsToSnapshot" : false,
        "crossAccountClone" : false,
        "domainMemberships" : [ ],
        "tagList" : [ ],
        "globalWriteForwardingStatus" : null,
        "globalWriteForwardingRequested" : null,
        "pendingModifiedValues" : null
      } ]
    }
  },
  "contentClass" : "com.fasterxml.jackson.databind.node.ObjectNode"
}

```