### PR TITLE
RDS Tweaks

### DIFF
--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryPlugin.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryPlugin.java
@@ -23,7 +23,7 @@ import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.OriginPlugin;
 import io.openraven.magpie.api.Session;
 import io.openraven.magpie.plugins.aws.discovery.services.EC2Discovery;
-import io.openraven.magpie.plugins.aws.discovery.services.RdsDiscovery;
+import io.openraven.magpie.plugins.aws.discovery.services.RDSDiscovery;
 import io.openraven.magpie.plugins.aws.discovery.services.S3Discovery;
 import org.slf4j.Logger;
 import software.amazon.awssdk.regions.Region;
@@ -39,7 +39,7 @@ public class AWSDiscoveryPlugin implements OriginPlugin<AWSDiscoveryConfig> {
 
   public final static String ID = "magpie.aws.discovery";
 
-  private static final List<AWSDiscovery> DISCOVERY_LIST = List.of(new EC2Discovery(), new S3Discovery(), new RdsDiscovery());
+  private static final List<AWSDiscovery> DISCOVERY_LIST = List.of(new EC2Discovery(), new S3Discovery(), new RDSDiscovery());
 
   private Logger logger;
   private AWSDiscoveryConfig config;


### PR DESCRIPTION
…lls do db.dbName() since it can be null for some clients (use dbInstanceArn instead).  Added the core configuration value to <rootNode>.configuration.  This should be a common practice across all resources