### PR TITLE
Added batch discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Magpie supports AWS as a core plugin out of the box. Checked boxes are complete 
 - [x] S3
 - [x] Athena
 - [ ] Backup
-- [ ] Batch
+- [x] Batch
 - [ ] Cassandra
 - [ ] Cloudfront
 - [ ] Cloudsearch

--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -39,6 +39,11 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>batch</artifactId>
+      <version>${aws.sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>ec2</artifactId>
       <version>${aws.sdk.version}</version>
     </dependency>

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryPlugin.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryPlugin.java
@@ -39,6 +39,7 @@ public class AWSDiscoveryPlugin implements OriginPlugin<AWSDiscoveryConfig> {
 
   private static final List<AWSDiscovery> DISCOVERY_LIST = List.of(
     new AthenaDiscovery(),
+    new BatchDiscovery(),
     new EC2Discovery(),
     new ECSDiscovery(),
     new LambdaDiscovery(),

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/BatchDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/BatchDiscovery.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Open Raven Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.api.Session;
+import org.slf4j.Logger;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.batch.BatchClient;
+
+import java.util.List;
+
+import static io.openraven.magpie.plugins.aws.discovery.AWSUtils.getAwsResponse;
+
+public class BatchDiscovery implements AWSDiscovery {
+
+  private static final String SERVICE = "batch";
+
+  @FunctionalInterface
+  interface LocalDiscovery {
+    void discover(ObjectMapper mapper, Session session, BatchClient client, Region region, Emitter emitter, Logger logger);
+  }
+
+  @Override
+  public String service() {
+    return SERVICE;
+  }
+
+  @Override
+  public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger) {
+    final var client = BatchClient.builder().region(region).build();
+
+    final List<LocalDiscovery> methods = List.of(
+      this::discoverComputeEnvironments,
+      this::discoverJobQueues,
+      this::discoverJobDefinitions
+    );
+
+    methods.forEach(m -> m.discover(mapper, session, client, region, emitter, logger));
+  }
+
+  private void discoverComputeEnvironments(ObjectMapper mapper, Session session, BatchClient client, Region region, Emitter emitter, Logger logger) {
+    getAwsResponse(
+      () -> client.describeComputeEnvironmentsPaginator().computeEnvironments(),
+      (resp) -> resp.forEach(computeEnvironment -> {
+        var data = mapper.createObjectNode();
+        data.putPOJO("configuration", computeEnvironment.toBuilder());
+        data.put("region", region.toString());
+
+        emitter.emit(new MagpieEnvelope(session, List.of(fullService() + ":computeEnvironment"), data));
+      }),
+      (noresp) -> logger.error("Failed to get computeEnvironments in {}", region)
+    );
+  }
+
+  private void discoverJobQueues(ObjectMapper mapper, Session session, BatchClient client, Region region, Emitter emitter, Logger logger) {
+    getAwsResponse(
+      () -> client.describeJobQueuesPaginator().jobQueues(),
+      (resp) -> resp.forEach(computeEnvironment -> {
+        var data = mapper.createObjectNode();
+        data.putPOJO("configuration", computeEnvironment.toBuilder());
+        data.put("region", region.toString());
+
+        emitter.emit(new MagpieEnvelope(session, List.of(fullService() + ":jobQueue"), data));
+      }),
+      (noresp) -> logger.error("Failed to get jobQueues in {}", region)
+    );
+
+  }
+
+  private void discoverJobDefinitions(ObjectMapper mapper, Session session, BatchClient client, Region region, Emitter emitter, Logger logger) {
+    getAwsResponse(
+      () -> client.describeJobDefinitionsPaginator().jobDefinitions(),
+      (resp) -> resp.forEach(computeEnvironment -> {
+        var data = mapper.createObjectNode();
+        data.putPOJO("configuration", computeEnvironment.toBuilder());
+        data.put("region", region.toString());
+
+        emitter.emit(new MagpieEnvelope(session, List.of(fullService() + ":jobDefinition"), data));
+      }),
+      (noresp) -> logger.error("Failed to get jobDefinitions in {}", region)
+    );
+  }
+}


### PR DESCRIPTION
Ref https://github.com/openraven/magpie/issues/24

On test and prod credentials there are only jobDefinition defined.
No data for jobQueues and computeEnvironment are present for testing

```
{
  "session" : {
    "id" : "52627d86-fefb-4da9-8301-b0afc3075f22",
    "createdAt" : "2021-03-29T12:43:33.829715Z"
  },
  "pluginPath" : [ "magpie.aws.discovery:batch:jobDefinition" ],
  "contents" : {
    "configuration" : {
      "jobDefinitionName" : "getting-started-job-definition",
      "jobDefinitionArn" : "arn:aws:batch:us-west-2:1234567890:job-definition/getting-started-job-definition:1",
      "revision" : 1,
      "status" : "INACTIVE",
      "type" : "container",
      "parameters" : { },
      "retryStrategy" : null,
      "containerProperties" : {
        "image" : "amazonlinux",
        "vcpus" : 2,
        "memory" : 2000,
        "command" : [ "echo", "hello world" ],
        "jobRoleArn" : null,
        "executionRoleArn" : null,
        "volumes" : [ ],
        "environment" : [ ],
        "mountPoints" : [ ],
        "readonlyRootFilesystem" : null,
        "privileged" : null,
        "ulimits" : [ ],
        "user" : null,
        "instanceType" : null,
        "resourceRequirements" : [ ],
        "linuxParameters" : null,
        "logConfiguration" : null,
        "secrets" : [ ],
        "networkConfiguration" : null,
        "fargatePlatformConfiguration" : null
      },
      "timeout" : null,
      "nodeProperties" : null,
      "tags" : { },
      "propagateTags" : null,
      "platformCapabilities" : null
    },
    "region" : "us-west-2"
  },
  "contentClass" : "com.fasterxml.jackson.databind.node.ObjectNode"
}
```
