### PR TITLE
Added ELB discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Magpie supports AWS as a core plugin out of the box. Checked boxes are complete 
 - [x] EFS
 - [x] EKS
 - [ ] Elastic Cache
-- [ ] ELB
+- [x] ELB
 - [ ] ELBv2
 - [ ] EMR
 - [ ] ESS

--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -85,6 +85,11 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>elasticloadbalancing</artifactId>
+      <version>${aws.sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>backup</artifactId>
       <version>${aws.sdk.version}</version>
     </dependency>

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryPlugin.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryPlugin.java
@@ -50,6 +50,7 @@ public class AWSDiscoveryPlugin implements OriginPlugin<AWSDiscoveryConfig> {
     new ECSDiscovery(),
     new EFSDiscovery(),    
     new EKSDiscovery(),
+    new ELBDiscovery(),
     new IAMDiscovery(),
     new LambdaDiscovery(),
     new S3Discovery(),

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/ELBDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/ELBDiscovery.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Open Raven Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.api.Session;
+import io.openraven.magpie.plugins.aws.discovery.AWSUtils;
+import org.slf4j.Logger;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.elasticloadbalancing.ElasticLoadBalancingClient;
+import software.amazon.awssdk.services.elasticloadbalancing.model.DescribeTagsRequest;
+import software.amazon.awssdk.services.elasticloadbalancing.model.LoadBalancerDescription;
+import software.amazon.awssdk.services.elasticloadbalancing.model.Tag;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.openraven.magpie.plugins.aws.discovery.AWSUtils.getAwsResponse;
+
+public class ELBDiscovery implements AWSDiscovery {
+
+  private static final String SERVICE = "elb";
+
+
+  @Override
+  public String service() {
+    return SERVICE;
+  }
+
+  @Override
+  public List<Region> getSupportedRegions() {
+    return ElasticLoadBalancingClient.serviceMetadata().regions();
+  }
+
+  @Override
+  public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger) {
+    final var client = ElasticLoadBalancingClient.builder().region(region).build();
+
+    getAwsResponse(
+      () -> client.describeLoadBalancers().loadBalancerDescriptions(),
+      (resp) -> resp.forEach(loadBalancer -> {
+        var data = mapper.createObjectNode();
+        data.putPOJO("configuration", loadBalancer.toBuilder());
+        data.put("region", region.toString());
+
+        discoverTags(client, loadBalancer, data, mapper);
+
+        emitter.emit(new MagpieEnvelope(session, List.of(fullService() + ":loadBalancer"), data));
+      }),
+      (noresp) -> logger.error("Failed to get loadBalancers in {}", region)
+    );
+  }
+
+  private void discoverTags(ElasticLoadBalancingClient client, LoadBalancerDescription resource, ObjectNode data, ObjectMapper mapper) {
+    var obj = data.putObject("tags");
+
+    getAwsResponse(
+      () -> client.describeTags(DescribeTagsRequest.builder().loadBalancerNames(resource.loadBalancerName()).build()).tagDescriptions(),
+      (resp) -> {
+        JsonNode tagsNode = mapper.convertValue(
+          resp.stream()
+          .flatMap(tagDescription -> tagDescription.tags().stream())
+          .collect(Collectors.toMap(Tag::key, Tag::value)), JsonNode.class);
+        AWSUtils.update(obj, tagsNode);
+      },
+      (noresp) -> AWSUtils.update(obj, noresp)
+    );
+  }
+}


### PR DESCRIPTION
Ref https://github.com/openraven/magpie/issues/55

```
{
  "configuration" : {
    "loadBalancerName" : "orvn-openra-K8SELB-5VKQT1MOEWKF",
    "dnsName" : "orvn-openra-K8SELB-5VKQT1MOEWKF-1210671634.us-west-2.elb.amazonaws.com",
    "canonicalHostedZoneName" : "orvn-openra-K8SELB-5VKQT1MOEWKF-1210671634.us-west-2.elb.amazonaws.com",
    "canonicalHostedZoneNameID" : "Z1H1FL5HABSF5",
    "listenerDescriptions" : [ {
      "listener" : {
        "protocol" : "TCP",
        "loadBalancerPort" : 6443,
        "instanceProtocol" : "TCP",
        "instancePort" : 6443,
        "sslCertificateId" : null
      },
      "policyNames" : [ ]
    } ],
    "policies" : {
      "appCookieStickinessPolicies" : [ ],
      "lbCookieStickinessPolicies" : [ ],
      "otherPolicies" : [ ]
    },
    "backendServerDescriptions" : [ ],
    "availabilityZones" : [ "us-west-2a" ],
    "subnets" : [ "subnet-05101a1db0b43e167" ],
    "vpcId" : "vpc-062acf9496baacac0",
    "instances" : [ {
      "instanceId" : "i-05d929a5989087da1"
    }, {
      "instanceId" : "i-01df7f95638ecff01"
    }, {
      "instanceId" : "i-01d7ae4f336e9f8fa"
    } ],
    "healthCheck" : {
      "target" : "HTTPS:6443/healthz",
      "interval" : 30,
      "timeout" : 5,
      "unhealthyThreshold" : 2,
      "healthyThreshold" : 2
    },
    "sourceSecurityGroup" : {
      "ownerAlias" : "XXXXXXXXXXXX",
      "groupName" : "orvn-openraven-net-KubeClusterStack-1AQPWJPPR7765-K8sElbSg-11YGFHAB19B0S"
    },
    "securityGroups" : [ "sg-0a8ab449916486f8b" ],
    "createdTime" : "2021-02-24T06:15:19.190Z",
    "scheme" : "internet-facing"
  },
  "region" : "us-west-2",
  "tags" : {
    "aws:cloudformation:stack-name" : "orvn-openraven-net-KubeClusterStack-1AQPWJPPR7765",
    "aws:cloudformation:stack-id" : "arn:aws:cloudformation:us-west-2:XXXXXXXXXXXX:stack/orvn-openraven-net-KubeClusterStack-1AQPWJPPR7765/90365140-7667-11eb-b190-0631c30a505b",
    "kubernetes.io/cluster/ClusterId" : "owned",
    "aws:cloudformation:logical-id" : "K8SELB",
    "project" : "openraven",
    "k8s.io/role/master" : "",
    "kubernetes.io/role/master" : "",
    "Name" : "openraven-ClusterId-kubernetes-api"
  }
}
```