### PR TITLE
Compilation warning fix

### DIFF
--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>magpie-aws</artifactId>
 
   <properties>
-    <project.version>${version}</project.version>
+    <project.version>${project.version}</project.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <aws.sdk.version>2.15.69</aws.sdk.version>

--- a/magpie-json/src/main/java/io/openraven/magpie/plugins/json/JSONPlugin.java
+++ b/magpie-json/src/main/java/io/openraven/magpie/plugins/json/JSONPlugin.java
@@ -45,7 +45,7 @@ public class JSONPlugin implements TerminalPlugin<Void> {
   public void accept(MagpieEnvelope env) {
     synchronized (SYNC) {
       try {
-        generator.writeObject(env);
+        generator.writeObject(env.getContents());
       } catch (IOException ex) {
         logger.warn("Couldn't process envelope contents", ex);
       }

--- a/magpie-json/src/main/java/io/openraven/magpie/plugins/json/JSONPlugin.java
+++ b/magpie-json/src/main/java/io/openraven/magpie/plugins/json/JSONPlugin.java
@@ -45,7 +45,7 @@ public class JSONPlugin implements TerminalPlugin<Void> {
   public void accept(MagpieEnvelope env) {
     synchronized (SYNC) {
       try {
-        generator.writeObject(env.getContents());
+        generator.writeObject(env);
       } catch (IOException ex) {
         logger.warn("Couldn't process envelope contents", ex);
       }


### PR DESCRIPTION
Fix for existing compilation warning:
```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.openraven.magpie:magpie-aws:jar:0.1.0-SNAPSHOT
[WARNING] The expression ${version} is deprecated. Please use ${project.version} instead.
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```
