### PR TITLE
Define AWS specific constant for lineseparator

### DIFF
--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/IAMDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/IAMDiscovery.java
@@ -43,6 +43,7 @@ import static io.openraven.magpie.plugins.aws.discovery.AWSUtils.getAwsResponse;
 public class IAMDiscovery implements AWSDiscovery {
 
   private static final String SERVICE = "iam";
+  private static final String AWS_LINE_SEPARATOR = "/n";
 
   @Override
   public String service() {
@@ -408,7 +409,7 @@ public class IAMDiscovery implements AWSDiscovery {
     var report = client.getCredentialReport();
     String reportContent = report.content().asUtf8String();
 
-    String[] reportLines = reportContent.split(System.getProperty("line.separator"));
+    String[] reportLines = reportContent.split(AWS_LINE_SEPARATOR);
 
     for (int i = 1; i < reportLines.length; i++) {
       var credential = new IAMCredential(reportLines[i]);


### PR DESCRIPTION
Since there only one usage of line separator in project, lets keep it in the same class
Will try to cover it with test for full IAM scope if possible in another commit.
