### PR TITLE
Discover all policies, not just Local scoped

### DIFF
--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/IAMDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/IAMDiscovery.java
@@ -128,7 +128,7 @@ public class IAMDiscovery implements AWSDiscovery {
     final String RESOURCE_TYPE = "AWS::IAM::Policy";
 
     try {
-      client.listPoliciesPaginator(builder -> builder.scope(PolicyScopeType.LOCAL)).policies().forEach(policy -> {
+      client.listPoliciesPaginator().policies().forEach(policy -> {
         var data = new AWSResource(policy.toBuilder(), region.toString(), account, mapper);
         data.arn = policy.arn();
         data.resourceId = policy.policyId();


### PR DESCRIPTION
Needed for rule 1.20 to discover `AWSSupportAccess` policy

This change adds ~7, 8 minutes to execution time when discovering `iam`  (before execution time was 2, now is 9 minutes)