### PR TITLE
Aws test container

### DIFF
--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -21,6 +21,8 @@
     <aws-sigv4-auth-cassandra-java-driver-plugin.version>4.0.3</aws-sigv4-auth-cassandra-java-driver-plugin.version>
     <magpie.api.version>0.1.2</magpie.api.version>
     <sentry.version>1.7.28</sentry.version>
+    <mockito.version>3.10.0</mockito.version>
+    <testcontainer.version>1.15.3</testcontainer.version>
   </properties>
 
   <dependencies>
@@ -207,6 +209,31 @@
       <artifactId>cloudwatch</artifactId>
       <version>${aws.sdk.version}</version>
     </dependency>
+    <dependency>
+      <groupId>software.aws.mcs</groupId>
+      <artifactId>aws-sigv4-auth-cassandra-java-driver-plugin</artifactId>
+      <version>${aws-sigv4-auth-cassandra-java-driver-plugin.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy-json</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-core-asl</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>2.7.0</version>
+      <scope>compile</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
@@ -242,31 +269,35 @@
       <version>1.2.3</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
-      <groupId>software.aws.mcs</groupId>
-      <artifactId>aws-sigv4-auth-cassandra-java-driver-plugin</artifactId>
-      <version>${aws-sigv4-auth-cassandra-java-driver-plugin.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy-json</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>jackson-core-asl</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-      <version>2.7.0</version>
-      <scope>compile</scope>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>${testcontainer.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
+      <version>${testcontainer.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>cloudformation</artifactId>
+      <version>${aws.sdk.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -304,6 +304,22 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M5</version>
+        <configuration>
+          <runOrder>random</runOrder>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
         <version>1.0.0</version>

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/AthenaDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/AthenaDiscovery.java
@@ -56,7 +56,7 @@ public class AthenaDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = AthenaClient.builder().region(region).build();
+    final var client = AWSUtils.configure(AthenaClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::Athena::DataCatalog";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/BackupDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/BackupDiscovery.java
@@ -54,7 +54,7 @@ public class BackupDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = BackupClient.builder().region(region).build();
+    final var client = AWSUtils.configure(BackupClient.builder(), region);
 
     final String RESOURCE_TYPE = "AWS::Backup::BackupVault";
 

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/BatchDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/BatchDiscovery.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.Session;
 import io.openraven.magpie.plugins.aws.discovery.AWSResource;
+import io.openraven.magpie.plugins.aws.discovery.AWSUtils;
 import io.openraven.magpie.plugins.aws.discovery.DiscoveryExceptions;
 import io.openraven.magpie.plugins.aws.discovery.VersionedMagpieEnvelopeProvider;
 import org.slf4j.Logger;
@@ -46,7 +47,7 @@ public class BatchDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = BatchClient.builder().region(region).build();
+    final var client = AWSUtils.configure(BatchClient.builder(), region);
 
     discoverComputeEnvironments(mapper, session, client, region, emitter, account);
     discoverJobQueues(mapper, session, client, region, emitter, account);

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/CloudFrontDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/CloudFrontDiscovery.java
@@ -54,7 +54,7 @@ public class CloudFrontDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = CloudFrontClient.builder().region(region).build();
+    final var client = AWSUtils.configure(CloudFrontClient.builder(), region);
     String RESOURCE_TYPE = "AWS::CloudFront::Distribution";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/CloudSearchDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/CloudSearchDiscovery.java
@@ -55,7 +55,7 @@ public class CloudSearchDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = CloudSearchClient.builder().region(region).build();
+    final var client = AWSUtils.configure(CloudSearchClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::CloudSearch::Domain";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/CloudTrailDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/CloudTrailDiscovery.java
@@ -53,7 +53,7 @@ public class CloudTrailDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = CloudTrailClient.builder().region(region).build();
+    final var client = AWSUtils.configure(CloudTrailClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::CloudTrail::Trail";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/CloudWatchDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/CloudWatchDiscovery.java
@@ -53,7 +53,7 @@ public class CloudWatchDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = CloudWatchClient.builder().region(region).build();
+    final var client = AWSUtils.configure(CloudWatchClient.builder(), region);
 
     discoverAlarms(mapper, session, region, emitter, client, account);
     discoverDashboards(mapper, session, region, emitter, client, account);

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/DynamoDbDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/DynamoDbDiscovery.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static io.openraven.magpie.plugins.aws.discovery.AWSUtils.configure;
 import static io.openraven.magpie.plugins.aws.discovery.AWSUtils.getAwsResponse;
 
 public class DynamoDbDiscovery implements AWSDiscovery {
@@ -54,13 +55,13 @@ public class DynamoDbDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = DynamoDbClient.builder().region(region).build();
+    final var client = configure(DynamoDbClient.builder(), region);
 
     discoverGlobalTables(mapper, session, region, emitter, client, account);
     discoverTables(mapper, session, region, emitter, client, account);
   }
 
-  private void discoverGlobalTables(ObjectMapper mapper, Session session, Region region, Emitter emitter, DynamoDbClient client, String account) {
+  protected void discoverGlobalTables(ObjectMapper mapper, Session session, Region region, Emitter emitter, DynamoDbClient client, String account) {
     final String RESOURCE_TYPE = "AWS::DynamoDB::GlobalTable";
     try {
       client.listGlobalTables().globalTables().stream()
@@ -79,7 +80,7 @@ public class DynamoDbDiscovery implements AWSDiscovery {
     }
   }
 
-  private void discoverTables(ObjectMapper mapper, Session session, Region region, Emitter emitter, DynamoDbClient client, String account) {
+  protected void discoverTables(ObjectMapper mapper, Session session, Region region, Emitter emitter, DynamoDbClient client, String account) {
     final String RESOURCE_TYPE = "AWS::DynamoDB::Table";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EBDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EBDiscovery.java
@@ -54,7 +54,7 @@ public class EBDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = ElasticBeanstalkClient.builder().region(region).build();
+    final var client = AWSUtils.configure(ElasticBeanstalkClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::ElasticBeanstalk";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EC2Discovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EC2Discovery.java
@@ -46,7 +46,7 @@ public class EC2Discovery implements AWSDiscovery {
   private static final String SERVICE = "ec2";
 
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = Ec2Client.builder().region(region).build();
+    final var client = AWSUtils.configure(Ec2Client.builder(), region);
 
     discoverEc2Instances(mapper, session, client, region, emitter, account);
     discoverEIPs(mapper, session, client, region, emitter, account);

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/ECSDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/ECSDiscovery.java
@@ -54,7 +54,7 @@ public class ECSDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = EcsClient.builder().region(region).build();
+    final var client = AWSUtils.configure(EcsClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::ECS::Cluster";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EFSDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EFSDiscovery.java
@@ -52,7 +52,7 @@ public class EFSDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = EfsClient.builder().region(region).build();
+    final var client = AWSUtils.configure(EfsClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::EFS::FileSystem";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EKSDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EKSDiscovery.java
@@ -52,7 +52,7 @@ public class EKSDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = EksClient.builder().region(region).build();
+    final var client = AWSUtils.configure(EksClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::EKS::Cluster";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/ELBDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/ELBDiscovery.java
@@ -55,7 +55,7 @@ public class ELBDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = ElasticLoadBalancingClient.builder().region(region).build();
+    final var client = AWSUtils.configure(ElasticLoadBalancingClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::ElasticLoadBalancing::LoadBalancer";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/ELBV2Discovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/ELBV2Discovery.java
@@ -55,7 +55,7 @@ public class ELBV2Discovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = ElasticLoadBalancingV2Client.builder().region(region).build();
+    final var client = AWSUtils.configure(ElasticLoadBalancingV2Client.builder(), region);
     final String RESOURCE_TYPE = "AWS::ElasticLoadBalancingV2::LoadBalancer";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EMRDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EMRDiscovery.java
@@ -52,7 +52,7 @@ public class EMRDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = EmrClient.builder().region(region).build();
+    final var client = AWSUtils.configure(EmrClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::EMR::Cluster";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/ESDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/ESDiscovery.java
@@ -57,7 +57,7 @@ public class ESDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = ElasticsearchClient.builder().region(region).build();
+    final var client = AWSUtils.configure(ElasticsearchClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::Elasticsearch::Domain";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/ElastiCacheDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/ElastiCacheDiscovery.java
@@ -55,7 +55,7 @@ public class ElastiCacheDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = ElastiCacheClient.builder().region(region).build();
+    final var client = AWSUtils.configure(ElastiCacheClient.builder(), region);
     final  String RESOURCE_TYPE = "AWS::ElastiCache::Cluster";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/FSXDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/FSXDiscovery.java
@@ -52,7 +52,7 @@ public class FSXDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = FSxClient.builder().region(region).build();
+    final var client = AWSUtils.configure(FSxClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::FSx::FileSystem";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/GlacierDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/GlacierDiscovery.java
@@ -53,7 +53,7 @@ public class GlacierDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = GlacierClient.builder().region(region).build();
+    final var client = AWSUtils.configure(GlacierClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::Glacier::Vault";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/IAMDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/IAMDiscovery.java
@@ -43,7 +43,7 @@ import static io.openraven.magpie.plugins.aws.discovery.AWSUtils.getAwsResponse;
 public class IAMDiscovery implements AWSDiscovery {
 
   private static final String SERVICE = "iam";
-  private static final String AWS_LINE_SEPARATOR = "/n";
+  private static final String AWS_LINE_SEPARATOR = "\n";
 
   @Override
   public String service() {
@@ -67,7 +67,7 @@ public class IAMDiscovery implements AWSDiscovery {
     discoverPolicies(client, mapper, session, region, emitter, account);
   }
 
-  private void discoverRoles(IamClient client, ObjectMapper mapper, Session session, Region region, Emitter emitter, String account) {
+  protected void discoverRoles(IamClient client, ObjectMapper mapper, Session session, Region region, Emitter emitter, String account) {
     final String RESOURCE_TYPE = "AWS::IAM::Role";
 
     try {
@@ -125,7 +125,7 @@ public class IAMDiscovery implements AWSDiscovery {
     AWSUtils.update(data.supplementaryConfiguration, Map.of("attachedPolicies", attachedPolicies));
   }
 
-  private void discoverPolicies(IamClient client, ObjectMapper mapper, Session session, Region region, Emitter emitter, String account) {
+  protected void discoverPolicies(IamClient client, ObjectMapper mapper, Session session, Region region, Emitter emitter, String account) {
     final String RESOURCE_TYPE = "AWS::IAM::Policy";
 
     try {
@@ -257,7 +257,7 @@ public class IAMDiscovery implements AWSDiscovery {
     );
   }
 
-  private void discoverGroups(IamClient client, ObjectMapper mapper, Session session, Region region, Emitter emitter, String account) {
+  protected void discoverGroups(IamClient client, ObjectMapper mapper, Session session, Region region, Emitter emitter, String account) {
     final String RESOURCE_TYPE = "AWS::IAM::Group";
 
     try {
@@ -312,7 +312,7 @@ public class IAMDiscovery implements AWSDiscovery {
     AWSUtils.update(data.supplementaryConfiguration, Map.of("attachedPolicies", attachedPolicies));
   }
 
-  private void discoverAccounts(IamClient client, ObjectMapper mapper, Session session, Region region, Emitter emitter, String account) {
+  protected void discoverAccounts(IamClient client, ObjectMapper mapper, Session session, Region region, Emitter emitter, String account) {
     final String RESOURCE_TYPE = "AWS::IAM::Account";
 
     try {
@@ -370,7 +370,7 @@ public class IAMDiscovery implements AWSDiscovery {
     );
   }
 
-  private void discoverCredentialsReport(IamClient client, ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
+  protected void discoverCredentialsReport(IamClient client, ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
     getAwsResponse(
       () -> generateCredentialReport(client),
       (resp) -> {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/IAMDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/IAMDiscovery.java
@@ -57,7 +57,7 @@ public class IAMDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = IamClient.builder().region(region).build();
+    final var client = AWSUtils.configure(IamClient.builder(), region);
 
     discoverCredentialsReport(client, mapper, session, region, emitter, logger, account);
     discoverAccounts(client, mapper, session, region, emitter, account);

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/KMSDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/KMSDiscovery.java
@@ -54,7 +54,7 @@ public class KMSDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = KmsClient.builder().region(region).build();
+    final var client = AWSUtils.configure(KmsClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::Kms::Key";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/LakeFormationDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/LakeFormationDiscovery.java
@@ -54,7 +54,7 @@ public class LakeFormationDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = LakeFormationClient.builder().region(region).build();
+    final var client = AWSUtils.configure(LakeFormationClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::LakeFormation::Resource";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/LambdaDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/LambdaDiscovery.java
@@ -52,7 +52,7 @@ public class LambdaDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = LambdaClient.builder().region(region).build();
+    final var client = AWSUtils.configure(LambdaClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::Lambda::Function";
     
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/LightsailDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/LightsailDiscovery.java
@@ -53,7 +53,7 @@ public class LightsailDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = LightsailClient.builder().region(region).build();
+    final var client = AWSUtils.configure(LightsailClient.builder(), region);
 
     discoverDatabases(mapper, session, region, emitter, client, account);
     discoverInstances(mapper, session, region, emitter, client, account);

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/QLDBDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/QLDBDiscovery.java
@@ -58,7 +58,7 @@ public class QLDBDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = QldbClient.builder().region(region).build();
+    final var client = AWSUtils.configure(QldbClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::Qldb::Ledger";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/RDSDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/RDSDiscovery.java
@@ -55,7 +55,7 @@ public class RDSDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = RdsClient.builder().region(region).build();
+    final var client = AWSUtils.configure(RdsClient.builder(), region);
 
     discoverDbSnapshot(mapper, session, region, emitter, logger, account, client);
     discoverDbInstances(mapper, session, region, emitter, logger, account, client);

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/RedshiftDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/RedshiftDiscovery.java
@@ -57,7 +57,7 @@ public class RedshiftDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = RedshiftClient.builder().region(region).build();
+    final var client = AWSUtils.configure(RedshiftClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::Redshift::Cluster";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/Route53Discovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/Route53Discovery.java
@@ -55,7 +55,7 @@ public class Route53Discovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = Route53Client.builder().region(region).build();
+    final var client = AWSUtils.configure(Route53Client.builder(), region);
     final  String RESOURCE_TYPE = "AWS::Route53::HostedZone";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/S3Discovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/S3Discovery.java
@@ -42,6 +42,7 @@ import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
+import static io.openraven.magpie.plugins.aws.discovery.AWSUtils.configure;
 import static io.openraven.magpie.plugins.aws.discovery.AWSUtils.getAwsResponse;
 
 public class S3Discovery implements AWSDiscovery {
@@ -67,7 +68,7 @@ public class S3Discovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = S3Client.builder().region(region).build();
+    final var client = configure(S3Client.builder(), region);
     final String RESOURCE_TYPE = "AWS::S3::Bucket";
 
     try {
@@ -110,9 +111,9 @@ public class S3Discovery implements AWSDiscovery {
   private Optional<List<Bucket>> getBuckets(Session session, S3Client client, Region bucketRegion, Logger logger) {
     try {
       //
-// This method is executed whenever the bucket cache does not contain entries for a given session ID.  This ensures
-// that we only make this expensive computation the lesser of once per scan or once per timeout period (defined above).
-//
+      // This method is executed whenever the bucket cache does not contain entries for a given session ID.  This ensures
+      // that we only make this expensive computation the lesser of once per scan or once per timeout period (defined above).
+      //
       var buckets = bucketCache.get(session.getId(), () -> {
         logger.debug("No cache found for {}, creating one now.", session);
         var map = new HashMap<Region, List<Bucket>>();
@@ -121,7 +122,9 @@ public class S3Discovery implements AWSDiscovery {
           final var location = resp.locationConstraint();
           // Thanks to https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model/GetBucketLocationResponse.html#locationConstraint--
           // we need to be aware of both null and UNKNOWN_TO_SDK_VERSION values.
-          var region = resp.locationConstraintAsString().isEmpty() ? Region.US_EAST_1 : Region.of(location.toString());
+          var region = Region.US_EAST_1.toString().equals(resp.locationConstraintAsString())
+            ? Region.US_EAST_1
+            : Region.of(location.toString());
           logger.debug("Associating {} to region {}", bucket.name(), region);
           var list = map.getOrDefault(region, new LinkedList<>());
           list.add(bucket);
@@ -163,7 +166,10 @@ public class S3Discovery implements AWSDiscovery {
           .bucket(resource.name())
           .build());
 
-      isPublicByPolicy = bucketPolicyStatus.policyStatus().isPublic();
+      // TODO : Does Null check required if policy not setup (catch with test)
+      isPublicByPolicy = bucketPolicyStatus.policyStatus().isPublic() != null
+        ? bucketPolicyStatus.policyStatus().isPublic()
+        : false;
     } catch (SdkServiceException ex) {
       if (!(ex.statusCode() == 403 || ex.statusCode() == 404)) {
         throw ex;

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/SNSDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/SNSDiscovery.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.Session;
 import io.openraven.magpie.plugins.aws.discovery.AWSResource;
+import io.openraven.magpie.plugins.aws.discovery.AWSUtils;
 import io.openraven.magpie.plugins.aws.discovery.DiscoveryExceptions;
 import io.openraven.magpie.plugins.aws.discovery.VersionedMagpieEnvelopeProvider;
 import org.slf4j.Logger;
@@ -49,7 +50,7 @@ public class SNSDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = SnsClient.builder().region(region).build();
+    final var client = AWSUtils.configure(SnsClient.builder(), region);
 
     discoverTopics(client, mapper, session, region, emitter, account);
     discoverSubscriptions(client, mapper, session, region, emitter, account);

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/SecretsManagerDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/SecretsManagerDiscovery.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.Session;
 import io.openraven.magpie.plugins.aws.discovery.AWSResource;
+import io.openraven.magpie.plugins.aws.discovery.AWSUtils;
 import io.openraven.magpie.plugins.aws.discovery.DiscoveryExceptions;
 import io.openraven.magpie.plugins.aws.discovery.VersionedMagpieEnvelopeProvider;
 import org.slf4j.Logger;
@@ -48,7 +49,7 @@ public class SecretsManagerDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = SecretsManagerClient.builder().region(region).build();
+    final var client = AWSUtils.configure(SecretsManagerClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::SecretsManager";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/StorageGatewayDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/StorageGatewayDiscovery.java
@@ -52,7 +52,7 @@ public class StorageGatewayDiscovery implements AWSDiscovery {
 
   @Override
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = StorageGatewayClient.builder().region(region).build();
+    final var client = AWSUtils.configure(StorageGatewayClient.builder(), region);
     final String RESOURCE_TYPE = "AWS::StorageGateway::Gateway";
 
     try {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/VPCDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/VPCDiscovery.java
@@ -20,10 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.Session;
-import io.openraven.magpie.plugins.aws.discovery.AWSDiscoveryPlugin;
-import io.openraven.magpie.plugins.aws.discovery.AWSResource;
-import io.openraven.magpie.plugins.aws.discovery.DiscoveryExceptions;
-import io.openraven.magpie.plugins.aws.discovery.VersionedMagpieEnvelopeProvider;
+import io.openraven.magpie.plugins.aws.discovery.*;
 import org.slf4j.Logger;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
@@ -41,7 +38,7 @@ public class VPCDiscovery implements AWSDiscovery {
   private static final String SERVICE = "vpc";
 
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account) {
-    final var client = Ec2Client.builder().region(region).build();
+    final var client = AWSUtils.configure(Ec2Client.builder(), region);
 
     discoverVpcs(mapper, session, client, region, emitter, account);
     discoverVpcPeeringConnections(mapper, session, client, region, emitter, account);

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/BaseAWSServiceIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/BaseAWSServiceIT.java
@@ -1,0 +1,95 @@
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.openraven.magpie.api.Session;
+import io.openraven.magpie.plugins.aws.discovery.AWSUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.CreateStackRequest;
+import software.amazon.awssdk.services.cloudformation.model.CreateStackResponse;
+import software.amazon.awssdk.services.cloudformation.model.UpdateStackRequest;
+import software.amazon.awssdk.services.cloudformation.model.UpdateStackResponse;
+
+import java.util.Objects;
+import java.util.Scanner;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.*;
+
+public abstract class BaseAWSServiceIT {
+
+  private static final int EXPOSED_EDGE_PORT = 4566;
+  protected static final String EMPTY_STACK_TEMPLATE_PATH = "/template/empty-stack.yml";
+  private static final String STACK_NAME = "integration-stack-" + System.nanoTime();
+
+  protected static final Region BASE_REGION = Region.US_WEST_1;
+  protected static final String ACCOUNT = "account";
+  protected static final Session SESSION = new Session();
+  protected static final Logger LOGGER = LoggerFactory.getLogger(BaseAWSServiceIT.class);
+
+  protected static final ObjectMapper MAPPER = new ObjectMapper()
+    .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+    .findAndRegisterModules();
+
+  protected static LocalStackContainer localStackContainer =
+    new LocalStackContainer(DockerImageName.parse("localstack/localstack:0.11.3"))
+      .withExposedPorts(EXPOSED_EDGE_PORT)
+      .withEnv("DEFAULT_REGION", BASE_REGION.id())
+      .withEnv("DEBUG", "1")
+      .withServices(DYNAMODB, CLOUDWATCH, S3, CLOUDFORMATION, IAM, SNS, SECRETSMANAGER); // At the moment cannot launch services dynamically
+
+  private static CloudFormationClient cfClient;
+
+  static {
+    localStackContainer.start();
+    setupEnvironment();
+    initiateCloudFormationClient();
+    startStackWithResources(EMPTY_STACK_TEMPLATE_PATH);
+  }
+
+  protected static void setupEnvironment() {
+    System.getProperties().setProperty("aws.accessKeyId", "foo");
+    System.getProperties().setProperty("aws.secretAccessKey", "bar");
+    System.getProperties().setProperty("MAGPIE_AWS_ENDPOINT",
+      String.format("http://%s:%d",
+        localStackContainer.getHost(),
+        localStackContainer.getMappedPort(EXPOSED_EDGE_PORT)));
+  }
+
+  protected static void initiateCloudFormationClient() {
+    cfClient = AWSUtils.configure(CloudFormationClient.builder(), BASE_REGION);
+  }
+
+  protected static void startStackWithResources(String templatePath) {
+    CreateStackRequest createStackRequest = CreateStackRequest.builder()
+      .stackName(STACK_NAME)
+      .templateBody(getResourceAsString(templatePath))
+      .build();
+
+    CreateStackResponse createdStack = cfClient.createStack(createStackRequest);
+    assertNotNull(createdStack.stackId());
+    LOGGER.info("Stack has been created with definition: {}", createdStack); // For transparency purpose
+  }
+
+  protected static void updateStackWithResources(String templatePath) {
+    UpdateStackRequest updateStackRequest = UpdateStackRequest.builder()
+      .stackName(STACK_NAME)
+      .templateBody(getResourceAsString(templatePath))
+      .build();
+
+    UpdateStackResponse updateStackResponse = cfClient.updateStack(updateStackRequest);
+    assertNotNull(updateStackResponse.stackId());
+    LOGGER.info("Stack has been updated with template: {}", templatePath);
+  }
+
+  protected static String getResourceAsString(String resourcePath) {
+    return new Scanner(Objects.requireNonNull(BaseAWSServiceIT.class.getResourceAsStream(resourcePath)), "UTF-8")
+      .useDelimiter("\\A").next();
+  }
+}

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/DynamoDbDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/DynamoDbDiscoveryIT.java
@@ -1,0 +1,62 @@
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.plugins.aws.discovery.AWSUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class DynamoDbDiscoveryIT extends BaseAWSServiceIT {
+
+  private static final String TEST_TABLE = "entities";
+  private static final String CF_DYNAMODB_TEMPLATE_PATH = "/template/dynamo-db-template.yml";
+
+  private final DynamoDbDiscovery dynamoDbDiscovery = new DynamoDbDiscovery();
+
+  @Mock
+  private Emitter emitter;
+
+  @Captor
+  private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
+
+  @BeforeAll
+  public static void setup() {
+    updateStackWithResources(CF_DYNAMODB_TEMPLATE_PATH);
+  }
+
+  @Test
+  public void testDynamoDBDiscovery() {
+    // given
+    DynamoDbClient dynamoDbClient = AWSUtils.configure(DynamoDbClient.builder(), BASE_REGION);
+
+    // when
+    dynamoDbDiscovery.discoverTables(
+      MAPPER,
+      SESSION,
+      BASE_REGION,
+      emitter,
+      dynamoDbClient,
+      ACCOUNT);
+
+    // then
+    Mockito.verify(emitter).emit(envelopeCapture.capture());
+    var contents = envelopeCapture.getValue().getContents();
+
+    assertNotNull(contents.get("documentId"));
+    assertEquals(String.format("arn:aws:dynamodb:%s:000000000000:table/%s", BASE_REGION, TEST_TABLE),
+      contents.get("arn").asText());
+    assertEquals(TEST_TABLE, contents.get("resourceName").asText());
+    assertEquals("AWS::DynamoDB::Table", contents.get("resourceType").asText());
+    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
+  }
+}

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/DynamoDbDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/DynamoDbDiscoveryIT.java
@@ -3,6 +3,7 @@ package io.openraven.magpie.plugins.aws.discovery.services;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieEnvelope;
 import io.openraven.magpie.plugins.aws.discovery.AWSUtils;
+import io.openraven.magpie.plugins.aws.discovery.services.base.BaseAWSServiceIT;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/EC2DiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/EC2DiscoveryIT.java
@@ -1,0 +1,183 @@
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.plugins.aws.discovery.services.base.BaseAWSServiceIT;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.atLeast;
+
+@ExtendWith(MockitoExtension.class)
+public class EC2DiscoveryIT extends BaseAWSServiceIT {
+
+  private static final String CF_EC2_TEMPLATE_PATH = "/template/ec2-template.yml";
+  private EC2Discovery ec2Discovery = new EC2Discovery();
+
+  @Mock
+  private Emitter emitter;
+
+  @Captor
+  private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
+
+  @BeforeAll
+  public static void setup() {
+    updateStackWithResources(CF_EC2_TEMPLATE_PATH);
+  }
+
+  @Test
+  public void testEC2Discovery() {
+    // when
+    ec2Discovery.discover(
+      MAPPER,
+      SESSION,
+      BASE_REGION,
+      emitter,
+      LOGGER,
+      ACCOUNT
+    );
+
+    // then
+    Mockito.verify(emitter, atLeast(1)).emit(envelopeCapture.capture());
+
+    var resources = envelopeCapture.getAllValues().stream()
+      .map(MagpieEnvelope::getContents)
+      .collect(Collectors.groupingBy(val -> val.get("resourceType").asText()));
+
+    assertInstance(resources.get("AWS::EC2::Instance"));
+    assertEIP(resources.get("AWS::EC2::EIP"));
+    assertSecurityGroup(resources.get("AWS::EC2::SecurityGroup"));
+    assertVolume(resources.get("AWS::EC2::Volume"));
+    assertSnapshot(resources.get("AWS::EC2::Snapshot"));
+  }
+
+  private void assertSnapshot(List<ObjectNode> data) {
+    assertEquals(36, data.size());
+    var contents = data.get(0);
+
+    assertNotNull(contents.get("documentId"));
+    assertTrue(contents.get("arn").asText().startsWith("arn:aws:ec2:us-west-1:account:snapshot/snap-"));
+    assertTrue(contents.get("resourceName").asText().startsWith("snap-"));
+    assertEquals(contents.get("resourceName").asText(), contents.get("resourceId").asText());
+    assertEquals("AWS::EC2::Snapshot", contents.get("resourceType").asText());
+    assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
+    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
+
+    var configuration = contents.get("configuration");
+    assertTrue(configuration.get("description").asText().startsWith("Auto-created snapshot for AMI ami-"));
+    assertEquals("completed", configuration.get("state").asText());
+    assertTrue(configuration.get("snapshotId").asText().startsWith("snap-"));
+  }
+
+  private void assertVolume(List<ObjectNode> data) {
+    assertEquals(1, data.size());
+    var contents = data.get(0);
+
+    assertNotNull(contents.get("documentId"));
+    assertTrue(contents.get("arn").asText().startsWith("arn:aws:ec2:us-west-1:account:volume/vol-"));
+    assertTrue(contents.get("resourceName").asText().startsWith("vol-"));
+    assertEquals(contents.get("resourceName").asText(), contents.get("resourceId").asText());
+    assertEquals("AWS::EC2::Volume", contents.get("resourceType").asText());
+    assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
+    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
+
+    var configuration = contents.get("configuration");
+    assertTrue(configuration.get("volumeId").asText().startsWith("vol-"));
+    assertEquals("standard", configuration.get("volumeType").asText());
+
+    var attachments = configuration.get("attachments");
+    assertEquals(1, attachments.size());
+    var attachment = attachments.get(0);
+    assertNotNull(attachment.get("attachTime").asText());
+    assertNotNull("/dev/sda1", attachment.get("device").asText());
+    assertTrue(attachment.get("instanceId").asText().startsWith("i-"));
+    assertTrue(attachment.get("volumeId").asText().startsWith("vol-"));
+    assertEquals("attached", attachment.get("state").asText());
+
+  }
+
+  private void assertSecurityGroup(List<ObjectNode> data) {
+    assertEquals(2, data.size()); // There default and default VPC
+    var contents = data.get(0);
+
+    assertNotNull(contents.get("documentId"));
+    assertTrue(contents.get("arn").asText().startsWith("arn:aws:ec2:us-west-1:account:security-group/sg-"));
+    assertEquals("default", contents.get("resourceName").asText());
+    assertTrue( contents.get("resourceId").asText().startsWith("sg-"));
+    assertEquals("AWS::EC2::SecurityGroup", contents.get("resourceType").asText());
+    assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
+    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
+
+    var configuration = contents.get("configuration");
+    assertEquals("default group", configuration.get("description").asText());
+    assertEquals("default", configuration.get("groupName").asText());
+    assertEquals("000000000000", configuration.get("ownerId").asText());
+  }
+
+  private void assertEIP(List<ObjectNode> data) {
+    assertEquals(1, data.size());
+    var contents = data.get(0);
+
+    assertNotNull(contents.get("documentId"));
+    assertEquals("arn:aws:ec2:us-west-1:account:eip-allocation/null", contents.get("arn").asText());
+    // IP Address
+    assertEquals(contents.get("resourceName").asText(), contents.get("configuration").get("publicIp").asText());
+    assertEquals("AWS::EC2::EIP", contents.get("resourceType").asText());
+    assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
+    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
+
+    var configuration = contents.get("configuration");
+    assertTrue(configuration.get("instanceId").asText().startsWith("i-"));
+    assertTrue(configuration.get("publicIp").asText().startsWith("127"));
+    assertTrue(configuration.get("networkInterfaceId").asText().startsWith("eni-"));
+    assertEquals("standard", configuration.get("domain").asText());
+  }
+
+  private void assertInstance(List<ObjectNode> data) {
+    assertEquals(1, data.size());
+    var contents = data.get(0);
+
+    assertNotNull(contents.get("documentId"));
+    assertTrue(contents.get("arn").asText().startsWith("arn:aws:ec2:us-west-1:000000000000:instance"));
+    assertFalse(contents.get("resourceName").asText().isEmpty());
+    assertEquals("AWS::EC2::Instance", contents.get("resourceType").asText());
+    assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
+    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
+
+    var configuration = contents.get("configuration");
+    assertTrue(configuration.get("imageId").asText().startsWith("ami-"));
+    assertTrue(configuration.get("instanceId").asText().startsWith("i-"));
+    assertEquals("m1.small", configuration.get("instanceType").asText());
+    assertEquals("testkey", configuration.get("keyName").asText());
+    assertNotNull(configuration.get("launchTime").asText());
+    assertTrue(configuration.get("placement").get("availabilityZone").asText().startsWith(BASE_REGION.toString()));
+
+    assertTrue(configuration.get("privateDnsName").asText().endsWith("us-west-1.compute.internal"));
+    assertFalse(configuration.get("privateIpAddress").asText().isEmpty());
+    assertTrue(configuration.get("publicDnsName").asText().endsWith("us-west-1.compute.amazonaws.com"));
+    assertFalse(configuration.get("publicIpAddress").asText().isEmpty());
+
+    var blockDeviceMappings = configuration.get("blockDeviceMappings");
+    assertEquals(1, blockDeviceMappings.size());
+    var device = blockDeviceMappings.get(0);
+    assertEquals("/dev/sda1", device.get("deviceName").asText());
+    assertEquals("in-use", device.get("ebs").get("status").asText());
+    assertTrue(device.get("ebs").get("volumeId").asText().startsWith("vol-"));
+    assertEquals("/dev/sda1" ,configuration.get("rootDeviceName").asText());
+    assertEquals("ebs" ,configuration.get("rootDeviceType").asText());
+    assertNotNull(configuration.get("publicIp").asText());
+  }
+}

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMAccountDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMAccountDiscoveryIT.java
@@ -1,0 +1,111 @@
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.api.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.iam.IamClient;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.atLeast;
+
+
+@ExtendWith(MockitoExtension.class)
+public class IAMAccountDiscoveryIT extends BaseAWSServiceIT {
+
+  private final String allias = "AccountTestAllias";
+  private final String mfaDeviceName = "testdevice";
+  private final IAMDiscovery iamDiscovery = new IAMDiscovery();
+
+  @Mock
+  private Emitter emitter;
+
+  @Captor
+  private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
+
+  @Test
+  public void testAccountDiscovery() {
+    var iamClient = IamClient.builder()
+      .endpointOverride(URI.create(System.getProperty("MAGPIE_AWS_ENDPOINT")))
+      .region(BASE_REGION)
+      .build();
+
+    // given
+    createAccountAlliases(iamClient, allias);
+    createPasswordPolicy(iamClient);
+    //createMFADevice(iamClient);
+
+    // when
+    iamDiscovery.discoverAccounts(
+      iamClient,
+      MAPPER,
+      SESSION,
+      BASE_REGION,
+      emitter,
+      ACCOUNT
+    );
+
+    // then
+    Mockito.verify(emitter, atLeast(1)).emit(envelopeCapture.capture());
+    assertEquals(1, envelopeCapture.getAllValues().size());
+    var envelope = envelopeCapture.getValue();
+
+    assertAccount(envelope);
+    assertConfiguration(envelope);
+  }
+
+  private void assertConfiguration(MagpieEnvelope envelope) {
+    var supplementaryConfiguration = envelope.getContents().get("supplementaryConfiguration");
+    var passwordPolicy = supplementaryConfiguration.get("PasswordPolicy");
+    assertEquals("{\"minimumPasswordLength\":8,\"requireSymbols\":true,\"requireNumbers\":true,\"requireUppercaseCharacters\":true,\"requireLowercaseCharacters\":true,\"allowUsersToChangePassword\":true,\"expirePasswords\":true,\"maxPasswordAge\":200,\"passwordReusePrevention\":1,\"hardExpiry\":true}",
+      passwordPolicy.toString());
+    var summaryMap = supplementaryConfiguration.get("summaryMap");
+    assertEquals("{\"GroupPolicySizeQuota\":5120,\"InstanceProfilesQuota\":1000,\"Policies\":0,\"GroupsPerUserQuota\":10,\"InstanceProfiles\":0,\"AttachedPoliciesPerUserQuota\":10,\"Users\":0,\"PoliciesQuota\":1500,\"Providers\":0,\"AccountMFAEnabled\":0,\"AccessKeysPerUserQuota\":2,\"AssumeRolePolicySizeQuota\":2048,\"PolicyVersionsInUseQuota\":10000,\"GlobalEndpointTokenVersion\":1,\"VersionsPerPolicyQuota\":5,\"AttachedPoliciesPerGroupQuota\":10,\"PolicySizeQuota\":6144,\"Groups\":0,\"AccountSigningCertificatesPresent\":0,\"UsersQuota\":5000,\"ServerCertificatesQuota\":20,\"MFADevices\":0,\"UserPolicySizeQuota\":2048,\"PolicyVersionsInUse\":0,\"ServerCertificates\":0,\"Roles\":0,\"RolesQuota\":1000,\"SigningCertificatesPerUserQuota\":2,\"MFADevicesInUse\":0,\"RolePolicySizeQuota\":10240,\"AttachedPoliciesPerRoleQuota\":10,\"AccountAccessKeysPresent\":0,\"GroupsQuota\":300}",
+      summaryMap.toString());
+  }
+
+  private void assertAccount(MagpieEnvelope envelope) {
+    var contents = envelopeCapture.getValue().getContents();
+    assertNotNull(contents.get("documentId").asText());
+    assertEquals("AWS::IAM::Account", contents.get("arn").asText());
+    assertEquals(allias, contents.get("resourceName").asText());
+    assertEquals("AWS::IAM::Account", contents.get("resourceType").asText());
+    assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
+    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
+  }
+
+  private void createMFADevice(IamClient iamClient) {
+    iamClient.createVirtualMFADevice(req -> req
+      .virtualMFADeviceName(mfaDeviceName));
+  }
+
+  private void createPasswordPolicy(IamClient iamClient) {
+    iamClient.updateAccountPasswordPolicy(req -> req
+      .maxPasswordAge(200)
+      .allowUsersToChangePassword(true)
+      .minimumPasswordLength(8)
+      .hardExpiry(true)
+      .passwordReusePrevention(1)
+      .requireLowercaseCharacters(true)
+      .requireNumbers(true)
+      .requireUppercaseCharacters(true)
+      .requireSymbols(true)
+    );
+  }
+
+  private void createAccountAlliases(IamClient iamClient, String allias) {
+    iamClient.createAccountAlias(req -> req.accountAlias(allias));
+  }
+
+
+
+}

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMCredentialReportDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMCredentialReportDiscoveryIT.java
@@ -2,6 +2,8 @@ package io.openraven.magpie.plugins.aws.discovery.services;
 
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.plugins.aws.discovery.services.base.BaseIAMServiceIT;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -9,15 +11,12 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.services.iam.IamClient;
-
-import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(MockitoExtension.class)
-class IAMCredentialReportDiscoveryIT extends BaseAWSServiceIT {
+class IAMCredentialReportDiscoveryIT extends BaseIAMServiceIT {
 
   private static final String TEST_USER = "testusername";
   private static final IAMDiscovery iamDiscovery = new IAMDiscovery();
@@ -30,16 +29,12 @@ class IAMCredentialReportDiscoveryIT extends BaseAWSServiceIT {
 
   @Test
   public void testCredentialReportDiscovery() {
-    //
-    IamClient iamClient = IamClient.builder()
-      .endpointOverride(URI.create(System.getProperty("MAGPIE_AWS_ENDPOINT")))
-      .region(BASE_REGION)
-      .build();
     // given
-    createIAMUser(iamClient, TEST_USER);
+    createIAMUser(TEST_USER);
+
     // when
     iamDiscovery.discoverCredentialsReport(
-      iamClient,
+      IAMCLIENT,
       MAPPER,
       SESSION,
       BASE_REGION,
@@ -61,7 +56,7 @@ class IAMCredentialReportDiscoveryIT extends BaseAWSServiceIT {
   }
 
 
-  private void createIAMUser(IamClient iamClient, String username ) {
-    iamClient.createUser(req -> req.userName(username));
+  private void createIAMUser(String username ) {
+    IAMCLIENT.createUser(req -> req.userName(username));
   }
 }

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMCredentialReportDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMCredentialReportDiscoveryIT.java
@@ -1,0 +1,67 @@
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.iam.IamClient;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+class IAMCredentialReportDiscoveryIT extends BaseAWSServiceIT {
+
+  private static final String TEST_USER = "testusername";
+  private static final IAMDiscovery iamDiscovery = new IAMDiscovery();
+
+  @Mock
+  private Emitter emitter;
+
+  @Captor
+  private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
+
+  @Test
+  public void testCredentialReportDiscovery() {
+    //
+    IamClient iamClient = IamClient.builder()
+      .endpointOverride(URI.create(System.getProperty("MAGPIE_AWS_ENDPOINT")))
+      .region(BASE_REGION)
+      .build();
+    // given
+    createIAMUser(iamClient, TEST_USER);
+    // when
+    iamDiscovery.discoverCredentialsReport(
+      iamClient,
+      MAPPER,
+      SESSION,
+      BASE_REGION,
+      emitter,
+      LOGGER,
+      ACCOUNT
+    );
+    // then
+    Mockito.verify(emitter).emit(envelopeCapture.capture());
+    var contents = envelopeCapture.getValue().getContents();
+
+    assertNotNull(contents.get("documentId"));
+    assertEquals(String.format("arn:aws:iam::000000000000:user/%s", TEST_USER), contents.get("arn").asText());
+    assertEquals(TEST_USER, contents.get("resourceName").asText());
+    assertEquals(String.format("arn:aws:iam::000000000000:user/%s", TEST_USER), contents.get("resourceId").asText());
+    assertEquals("AWS::IAM::CredentialsReport", contents.get("resourceType").asText());
+    assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
+    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
+  }
+
+
+  private void createIAMUser(IamClient iamClient, String username ) {
+    iamClient.createUser(req -> req.userName(username));
+  }
+}

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMGroupDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMGroupDiscoveryIT.java
@@ -39,7 +39,7 @@ public class IAMGroupDiscoveryIT extends BaseIAMServiceIT {
 
   @AfterAll
   public static void clenup() {
-    removeRoles();
+    removePolicies();
   }
 
   @Test

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMGroupDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMGroupDiscoveryIT.java
@@ -1,0 +1,128 @@
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.api.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.model.CreatePolicyResponse;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.atLeast;
+
+/**
+ * Covered IAM Groups. ResourceGroups not covered
+ */
+@ExtendWith(MockitoExtension.class)
+public class IAMGroupDiscoveryIT extends BaseAWSServiceIT {
+
+  private final String POLICY_DOCUMENT_PATH = "/document/policy-dynamodb-access.json";
+  private final String INLINE_POLICY_DOCUMENT_PATH = "/document/policy-dynamodb-inline.json";
+  private final String GROUP_NAME = "Accountants";
+  private final String MANAGED_POLICY_NAME = "managedDataAccess";
+  private final String INLINE_POLICY_NAME = "inlineDataAccess";
+
+  private final IAMDiscovery iamDiscovery = new IAMDiscovery();
+
+  @Mock
+  private Emitter emitter;
+
+  @Captor
+  private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
+
+  @Test
+  public void testGroupDiscovery() {
+    IamClient iamClient = IamClient.builder()
+      .endpointOverride(URI.create(System.getProperty("MAGPIE_AWS_ENDPOINT")))
+      .region(BASE_REGION)
+      .build();
+
+    // Group creation failing with CF template. Fallback to SDK manual approach
+    createGroupWithInlinePolicy(iamClient);
+    String attachedPolicyArn = createPolicyAndAttach(iamClient);
+
+    // when
+    iamDiscovery.discoverGroups(
+      iamClient,
+      MAPPER,
+      SESSION,
+      BASE_REGION,
+      emitter,
+      ACCOUNT
+    );
+
+    // then
+    Mockito.verify(emitter, atLeast(1)).emit(envelopeCapture.capture());
+    assertEquals(1, envelopeCapture.getAllValues().size());
+    MagpieEnvelope envelope = envelopeCapture.getValue();
+
+    assertGroup(envelope);
+    assertInlinePolicies(envelope);
+    assertAttachedPolicies(envelope);
+
+    //clenup
+    iamClient.deletePolicy(req -> req.policyArn(attachedPolicyArn));
+    iamClient.deleteGroup(req -> req.groupName(GROUP_NAME));
+  }
+
+  private void assertGroup(MagpieEnvelope envelope) {
+    var contents = envelope.getContents();
+    assertNotNull(contents.get("documentId"));
+    assertEquals(String.format("arn:aws:iam::000000000000:group/%s", GROUP_NAME), contents.get("arn").asText());
+    assertEquals(GROUP_NAME, contents.get("resourceName").asText());
+    assertNotNull(contents.get("resourceId").asText());
+    assertEquals("AWS::IAM::Group", contents.get("resourceType").asText());
+    assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
+    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
+  }
+
+  private void assertInlinePolicies(MagpieEnvelope envelope) {
+    var inlinePolicies = envelope.getContents().get("supplementaryConfiguration").get("inlinePolicies");
+    assertEquals(1, inlinePolicies.size());
+
+    var inlinePolicy = inlinePolicies.get(0);
+    assertEquals("inlineDataAccess", inlinePolicy.get("name").asText());
+    assertEquals(getResourceAsString(INLINE_POLICY_DOCUMENT_PATH), inlinePolicy.get("policyDocument").asText());
+  }
+
+  private void assertAttachedPolicies(MagpieEnvelope envelope) {
+    var attachedPolicies = envelope.getContents().get("supplementaryConfiguration").get("attachedPolicies");
+    assertEquals(1, attachedPolicies.size());
+
+    var policy = attachedPolicies.get(0);
+    assertEquals("managedDataAccess", policy.get("name").asText());
+    assertEquals(String.format("arn:aws:iam::000000000000:policy/%s", MANAGED_POLICY_NAME), policy.get("arn").asText());
+
+  }
+
+  private void createGroupWithInlinePolicy(IamClient iamClient) {
+    iamClient.createGroup(request -> {
+      request.groupName(GROUP_NAME);
+    });
+    iamClient.putGroupPolicy(p -> p
+      .groupName(GROUP_NAME)
+      .policyName(INLINE_POLICY_NAME)
+      .policyDocument(getResourceAsString(INLINE_POLICY_DOCUMENT_PATH))
+    );
+  }
+
+  private String createPolicyAndAttach(IamClient iamClient) {
+    CreatePolicyResponse policyResp = iamClient.createPolicy(policyRequest -> policyRequest
+      .policyName(MANAGED_POLICY_NAME)
+      .description("Tax data access")
+      .policyDocument(getResourceAsString(POLICY_DOCUMENT_PATH))
+    );
+
+    iamClient.attachGroupPolicy(attach -> attach.groupName(GROUP_NAME).policyArn(policyResp.policy().arn()));
+    return policyResp.policy().arn();
+  }
+}

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMPolicyDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMPolicyDiscoveryIT.java
@@ -3,6 +3,7 @@ package io.openraven.magpie.plugins.aws.discovery.services;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieEnvelope;
 import io.openraven.magpie.plugins.aws.discovery.services.base.BaseIAMServiceIT;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -28,6 +29,11 @@ public class IAMPolicyDiscoveryIT extends BaseIAMServiceIT {
 
   @Captor
   private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
+
+  @AfterAll
+  public static void cleanup() {
+    removePolicies();
+  }
 
   @Test
   public void testPolicyDiscovery() {

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMPolicyDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMPolicyDiscoveryIT.java
@@ -1,0 +1,107 @@
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.api.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.iam.IamClient;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.atLeast;
+
+@ExtendWith(MockitoExtension.class)
+public class IAMPolicyDiscoveryIT extends BaseAWSServiceIT {
+
+  private final String POLICY_DYNAMODB_PATH = "/document/policy-dynamodb-access.json";
+  private final String POLICY_DYNAMODB_UPDATED_PATH = "/document/policy-dynamodb-updated-access.json";
+  private final String POLICY_NAME = "PolicyDataAccess";
+  private final IAMDiscovery iamDiscovery = new IAMDiscovery();
+
+  @Mock
+  private Emitter emitter;
+
+  @Captor
+  private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
+
+  @Test
+  public void testPolicyDiscovery() {
+
+    var iamClient = IamClient.builder()
+      .endpointOverride(URI.create(System.getProperty("MAGPIE_AWS_ENDPOINT")))
+      .region(BASE_REGION)
+      .build();
+
+    // then
+    var policyArn = createPolicy(iamClient);
+    createPolicyVersion(iamClient, policyArn);
+    // when
+    iamDiscovery.discoverPolicies(
+      iamClient,
+      MAPPER,
+      SESSION,
+      BASE_REGION,
+      emitter,
+      ACCOUNT
+    );
+
+    // then
+    Mockito.verify(emitter, atLeast(1)).emit(envelopeCapture.capture());
+    var envelope = envelopeCapture.getValue();
+
+    assertPolicy(envelope);
+    assertConfiguration(envelope);
+    assertPolicyDocument(envelope);
+  }
+
+  private void assertPolicyDocument(MagpieEnvelope envelope) {
+    var supplementaryConfiguration = envelope.getContents().get("supplementaryConfiguration");
+    var attachedPolicies = supplementaryConfiguration.get("attachedPolicies");
+    var policyDocument = attachedPolicies.get("policyDocument").asText();
+    assertEquals(getResourceAsString(POLICY_DYNAMODB_UPDATED_PATH), policyDocument);
+  }
+
+  private void assertConfiguration(MagpieEnvelope envelope) {
+    var configuration = envelope.getContents().get("configuration");
+    assertEquals(POLICY_NAME, configuration.get("policyName").asText());
+    assertEquals("v2", configuration.get("defaultVersionId").asText()); // Second Version should be default
+  }
+
+  private void assertPolicy(MagpieEnvelope envelope) {
+    var contents = envelope.getContents();
+    assertNotNull(contents.get("documentId"));
+    assertEquals(String.format("arn:aws:iam::000000000000:policy/%s", POLICY_NAME), contents.get("arn").asText());
+    assertEquals(POLICY_NAME, contents.get("resourceName").asText());
+    assertNotNull(contents.get("resourceId").asText());
+    assertEquals("AWS::IAM::Policy", contents.get("resourceType").asText());
+    assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
+    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
+  }
+
+  private String createPolicy(IamClient iamClient) {
+    return iamClient.createPolicy(policyRequest -> policyRequest
+        .policyName(POLICY_NAME)
+        .description("Tax data access")
+        .policyDocument(getResourceAsString(POLICY_DYNAMODB_PATH)))
+      .policy()
+      .arn();
+  }
+
+  private void createPolicyVersion(IamClient iamClient, String arn) {
+    iamClient.createPolicyVersion(policyVersion -> policyVersion
+      .policyArn(arn)
+      .policyDocument(getResourceAsString(POLICY_DYNAMODB_UPDATED_PATH))
+      .setAsDefault(true));
+  }
+
+}

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMPolicyDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMPolicyDiscoveryIT.java
@@ -1,10 +1,8 @@
 package io.openraven.magpie.plugins.aws.discovery.services;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieEnvelope;
-import io.openraven.magpie.api.Session;
+import io.openraven.magpie.plugins.aws.discovery.services.base.BaseIAMServiceIT;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -12,16 +10,13 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.services.iam.IamClient;
-
-import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.atLeast;
 
 @ExtendWith(MockitoExtension.class)
-public class IAMPolicyDiscoveryIT extends BaseAWSServiceIT {
+public class IAMPolicyDiscoveryIT extends BaseIAMServiceIT {
 
   private final String POLICY_DYNAMODB_PATH = "/document/policy-dynamodb-access.json";
   private final String POLICY_DYNAMODB_UPDATED_PATH = "/document/policy-dynamodb-updated-access.json";
@@ -36,25 +31,18 @@ public class IAMPolicyDiscoveryIT extends BaseAWSServiceIT {
 
   @Test
   public void testPolicyDiscovery() {
-
-    var iamClient = IamClient.builder()
-      .endpointOverride(URI.create(System.getProperty("MAGPIE_AWS_ENDPOINT")))
-      .region(BASE_REGION)
-      .build();
-
     // then
-    var policyArn = createPolicy(iamClient);
-    createPolicyVersion(iamClient, policyArn);
+    var policyArn = createPolicy();
+    createPolicyVersion(policyArn);
     // when
     iamDiscovery.discoverPolicies(
-      iamClient,
+      IAMCLIENT,
       MAPPER,
       SESSION,
       BASE_REGION,
       emitter,
       ACCOUNT
     );
-
     // then
     Mockito.verify(emitter, atLeast(1)).emit(envelopeCapture.capture());
     var envelope = envelopeCapture.getValue();
@@ -88,8 +76,8 @@ public class IAMPolicyDiscoveryIT extends BaseAWSServiceIT {
     assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
   }
 
-  private String createPolicy(IamClient iamClient) {
-    return iamClient.createPolicy(policyRequest -> policyRequest
+  private String createPolicy() {
+    return IAMCLIENT.createPolicy(policyRequest -> policyRequest
         .policyName(POLICY_NAME)
         .description("Tax data access")
         .policyDocument(getResourceAsString(POLICY_DYNAMODB_PATH)))
@@ -97,8 +85,8 @@ public class IAMPolicyDiscoveryIT extends BaseAWSServiceIT {
       .arn();
   }
 
-  private void createPolicyVersion(IamClient iamClient, String arn) {
-    iamClient.createPolicyVersion(policyVersion -> policyVersion
+  private void createPolicyVersion(String arn) {
+    IAMCLIENT.createPolicyVersion(policyVersion -> policyVersion
       .policyArn(arn)
       .policyDocument(getResourceAsString(POLICY_DYNAMODB_UPDATED_PATH))
       .setAsDefault(true));

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMRoleDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMRoleDiscoveryIT.java
@@ -1,0 +1,105 @@
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.api.Session;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.waiters.WaiterResponse;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.model.GetPolicyResponse;
+import software.amazon.awssdk.services.iam.waiters.IamWaiter;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeast;
+
+@ExtendWith(MockitoExtension.class)
+public class IAMRoleDiscoveryIT extends BaseAWSServiceIT {
+  private static final String CF_IAM_ROLE_TEMPLATE_PATH = "/template/iam-role-template.yml";
+  private static final String ROLE_NAME = "RootRole";
+
+  private final IAMDiscovery iamDiscovery = new IAMDiscovery();
+
+  @Mock
+  private Emitter emitter;
+
+  @Captor
+  private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
+
+  @BeforeAll
+  public static void setup() {
+    updateStackWithResources(CF_IAM_ROLE_TEMPLATE_PATH);
+  }
+
+  @Test
+  public void testRoleDiscovery() {
+    IamClient iamClient = IamClient.builder()
+      .endpointOverride(URI.create(System.getProperty("MAGPIE_AWS_ENDPOINT")))
+      .region(BASE_REGION)
+      .build();
+
+    // when
+    iamDiscovery.discoverRoles(
+      iamClient,
+      MAPPER,
+      SESSION,
+      BASE_REGION,
+      emitter,
+      ACCOUNT
+    );
+
+    // then
+    Mockito.verify(emitter, atLeast(1)).emit(envelopeCapture.capture());
+    assertEquals(1, envelopeCapture.getAllValues().size());
+    MagpieEnvelope envelope = envelopeCapture.getValue();
+    ObjectNode contents = envelope.getContents();
+
+    assertRole(envelope);
+    assertConfiguration(envelope);
+    assertInlinePolicy(envelope);
+
+  }
+
+  private void assertRole(MagpieEnvelope envelope) {
+    var contents = envelope.getContents();
+    assertNotNull(contents.get("documentId"));
+    assertTrue(contents.get("arn").asText().contains(ROLE_NAME));
+    assertTrue(contents.get("resourceName").asText().contains(ROLE_NAME));
+    assertNotNull(contents.get("resourceId").asText());
+    assertEquals("AWS::IAM::Role", contents.get("resourceType").asText());
+    assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
+    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
+  }
+
+  private void assertConfiguration(MagpieEnvelope envelope) {
+    var configuration = envelope.getContents().get("configuration");
+    assertEquals("/", configuration.get("path").asText());
+    assertNotNull(configuration.get("roleId"));
+    assertTrue(configuration.get("arn").asText().contains(ROLE_NAME));
+    assertNotNull(configuration.get("createDate"));
+    assertNotNull(configuration.get("assumeRolePolicyDocument"));
+  }
+
+  private void assertInlinePolicy(MagpieEnvelope envelope) {
+    var inlinePolicies = envelope.getContents().get("supplementaryConfiguration").get("inlinePolicies");
+    assertEquals(1, inlinePolicies.size());
+
+    var inlinePolicy = inlinePolicies.get(0);
+    assertEquals("inlinePolicy", inlinePolicy.get("name").asText());
+    assertEquals("{'Version': '2012-10-17', 'Statement': [{'Effect': 'Allow', 'Action': '*', 'Resource': '*'}]}",
+      inlinePolicy.get("policyDocument").asText()
+      );
+  }
+}
+

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMRoleDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMRoleDiscoveryIT.java
@@ -39,7 +39,7 @@ public class IAMRoleDiscoveryIT extends BaseIAMServiceIT {
 
   @AfterAll
   public static void cleanup() {
-    removeRoles();
+    removePolicies();
   }
 
   @Test

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/LambdaDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/LambdaDiscoveryIT.java
@@ -4,6 +4,8 @@ package io.openraven.magpie.plugins.aws.discovery.services;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieEnvelope;
 import io.openraven.magpie.plugins.aws.discovery.services.base.BaseAWSServiceIT;
+import io.openraven.magpie.plugins.aws.discovery.services.base.BaseIAMServiceIT;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,7 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
-public class LambdaDiscoveryIT extends BaseAWSServiceIT {
+public class LambdaDiscoveryIT extends BaseIAMServiceIT {
 
   private static final String CF_LAMBDA_TEMPLATE_PATH = "/template/lambda-template.yml";
   private LambdaDiscovery lambdaDiscovery = new LambdaDiscovery();
@@ -30,6 +32,11 @@ public class LambdaDiscoveryIT extends BaseAWSServiceIT {
   @BeforeAll
   public static void setup() {
     updateStackWithResources(CF_LAMBDA_TEMPLATE_PATH);
+  }
+
+  @AfterAll
+  public static void cleanup() {
+    removePolicies();
   }
 
   /**

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/LambdaDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/LambdaDiscoveryIT.java
@@ -1,0 +1,82 @@
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.plugins.aws.discovery.services.base.BaseAWSServiceIT;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class LambdaDiscoveryIT extends BaseAWSServiceIT {
+
+  private static final String CF_LAMBDA_TEMPLATE_PATH = "/template/lambda-template.yml";
+  private LambdaDiscovery lambdaDiscovery = new LambdaDiscovery();
+
+  @Mock
+  private Emitter emitter;
+
+  @Captor
+  private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
+
+  @BeforeAll
+  public static void setup() {
+    updateStackWithResources(CF_LAMBDA_TEMPLATE_PATH);
+  }
+
+  /**
+   *  Issue with localstack response under the method client.getFunctionEventInvokeConfig
+   *  Unable to parse date format. Hence fallback to simpler template
+   */
+  @Test
+  public void testLambdaDiscovery() {
+    // then
+    lambdaDiscovery.discover(
+      MAPPER,
+      SESSION,
+      BASE_REGION,
+      emitter,
+      LOGGER,
+      ACCOUNT
+    );
+
+    // then
+    Mockito.verify(emitter).emit(envelopeCapture.capture());
+    var envelope = envelopeCapture.getValue();
+
+    assertBase(envelope);
+    assertConfiguration(envelope);
+  }
+
+  private void assertBase(MagpieEnvelope envelope) {
+    var base = envelope.getContents();
+    assertNotNull(base.get("documentId"));
+    assertTrue(base.get("arn").asText().contains("arn:aws:lambda:us-west-1:000000000000:function:integration-stack"));
+    assertNotNull(base.get("resourceName").asText());
+    assertNotNull(base.get("resourceId").asText());
+    assertEquals("AWS::Lambda::Function", base.get("resourceType").asText());
+    assertEquals(ACCOUNT, base.get("awsAccountId").asText());
+    assertEquals(BASE_REGION.toString(), base.get("awsRegion").asText());
+  }
+
+  private void assertConfiguration(MagpieEnvelope envelope) {
+    var configuration = envelope.getContents().get("configuration");
+    assertTrue(configuration.get("functionName").asText().contains("lambda"));
+    assertTrue(configuration.get("functionArn").asText()
+      .contains("arn:aws:lambda:us-west-1:000000000000:function:integration-stack"));
+    assertEquals("nodejs12.x", configuration.get("runtime").asText());
+    assertEquals("arn:aws:iam::000000000000:role/lambda-role", configuration.get("role").asText());
+    assertEquals("index.handler", configuration.get("handler").asText());
+    assertEquals("$LATEST", configuration.get("version").asText());
+    assertEquals("Zip", configuration.get("packageType").asText());
+  }
+
+}

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/Route53DiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/Route53DiscoveryIT.java
@@ -11,15 +11,14 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
-class S3DiscoveryIT extends BaseAWSServiceIT {
+public class Route53DiscoveryIT extends BaseAWSServiceIT {
 
-  private static final String BUCKET_NAME = "testbucket";
-  private static final String CF_S3_TEMPLATE_PATH = "/template/s3-template.yml";
-
-  private final S3Discovery s3Discovery = new S3Discovery();
+  private static final String CF_ROUTE53_TEMPLATE_PATH = "/template/route53-template.yml";
+  private final Route53Discovery route53Discovery = new Route53Discovery();
 
   @Mock
   private Emitter emitter;
@@ -30,13 +29,13 @@ class S3DiscoveryIT extends BaseAWSServiceIT {
   @BeforeAll
   public static void setup() {
     // given
-    updateStackWithResources(CF_S3_TEMPLATE_PATH);
+    updateStackWithResources(CF_ROUTE53_TEMPLATE_PATH);
   }
 
   @Test
-  public void testS3Discovery() {
+  public void testRoute53Discovery() {
     // when
-    s3Discovery.discover(
+    route53Discovery.discover(
       MAPPER,
       SESSION,
       BASE_REGION,
@@ -50,13 +49,10 @@ class S3DiscoveryIT extends BaseAWSServiceIT {
     var contents = envelopeCapture.getValue().getContents();
 
     assertNotNull(contents.get("documentId"));
-    assertEquals("arn:aws:s3:::testbucket", contents.get("arn").asText());
-    assertEquals(BUCKET_NAME, contents.get("resourceName").asText());
-    assertEquals("AWS::S3::Bucket", contents.get("resourceType").asText());
+    assertTrue(contents.get("arn").asText().contains("arn:aws:route53:::hostedZone"));
+    assertEquals("example.com", contents.get("resourceName").asText());
+    assertEquals("AWS::Route53::HostedZone", contents.get("resourceType").asText());
     assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
     assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
   }
 }
-
-
-

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/S3DiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/S3DiscoveryIT.java
@@ -1,0 +1,61 @@
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.api.Session;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class S3DiscoveryIT extends BaseAWSServiceIT {
+
+  private static final String BUCKET_NAME = "testbucket";
+  private static final String CF_S3_TEMPLATE_PATH = "/template/s3-template.yml";
+
+  private final S3Discovery s3Discovery = new S3Discovery();
+
+  @Mock
+  private Emitter emitter;
+
+  @Captor
+  private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
+
+  @BeforeAll
+  public static void setup() {
+    updateStackWithResources(CF_S3_TEMPLATE_PATH);
+  }
+
+  @Test
+  public void testS3Discovery() {
+    s3Discovery.discover(
+      MAPPER,
+      SESSION,
+      BASE_REGION,
+      emitter,
+      LOGGER,
+      ACCOUNT
+    );
+
+    // Verify
+    Mockito.verify(emitter).emit(envelopeCapture.capture());
+    var contents = envelopeCapture.getValue().getContents();
+
+    assertNotNull(contents.get("documentId"));
+    assertEquals("arn:aws:s3:::testbucket", contents.get("arn").asText());
+    assertEquals(BUCKET_NAME, contents.get("resourceName").asText());
+    assertEquals("AWS::S3::Bucket", contents.get("resourceType").asText());
+    assertEquals("account", contents.get("awsAccountId").asText());
+    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
+  }
+}
+
+
+

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/SNSDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/SNSDiscoveryIT.java
@@ -1,0 +1,73 @@
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.api.Session;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class SNSDiscoveryIT extends BaseAWSServiceIT {
+  private static final String CF_SNS_TEMPLATE = "/template/sns-subscription-template.yml";
+  private final SNSDiscovery snsDiscovery = new SNSDiscovery();
+
+  @Mock
+  private Emitter emitter;
+
+  @Captor
+  private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
+
+  @BeforeAll
+  public static void setup() {
+    updateStackWithResources(CF_SNS_TEMPLATE);
+  }
+
+  @Test
+  public void testSNSDiscovery() {
+    snsDiscovery.discover(
+      MAPPER,
+      SESSION,
+      BASE_REGION,
+      emitter,
+      LOGGER,
+      ACCOUNT
+    );
+
+    // Verify
+    Mockito.verify(emitter, times(2)).emit(envelopeCapture.capture());
+    var invocations = envelopeCapture.getAllValues();
+    assertEquals(2, invocations.size());
+    assertTopic(invocations.get(0));
+    assertSubscription(invocations.get(1));
+  }
+
+  private void assertTopic(MagpieEnvelope envelope) {
+    var content = envelope.getContents();
+    assertNotNull(content.get("documentId"));
+    assertTrue(content.get("arn").asText().contains("arn:aws:sns:us-west-1:000000000000:CarSalesTopic"));
+    assertEquals("AWS::SNS::Topic", content.get("resourceType").asText());
+    assertEquals(BASE_REGION.toString(), content.get("awsRegion").asText());
+  }
+
+  private void assertSubscription(MagpieEnvelope envelope) {
+    var content = envelope.getContents();
+    assertNotNull(content.get("documentId"));
+    assertNotNull(content.get("resourceName"));
+    assertTrue(content.get("arn").asText().contains("arn:aws:sns:us-west-1:000000000000:CarSalesTopic"));
+    assertEquals("AWS::SNS::Subscription", content.get("resourceType").asText());
+    assertEquals("test@openraven.com", content.get("configuration").get("attributes").get("Endpoint").asText());
+    assertTrue(content.get("configuration").get("attributes").get("TopicArn").asText().contains("arn:aws:sns:us-west-1:000000000000:CarSalesTopic"));
+    assertEquals(BASE_REGION.toString(), content.get("awsRegion").asText());
+  }
+}

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/SNSDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/SNSDiscoveryIT.java
@@ -3,7 +3,7 @@ package io.openraven.magpie.plugins.aws.discovery.services;
 
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieEnvelope;
-import io.openraven.magpie.api.Session;
+import io.openraven.magpie.plugins.aws.discovery.services.base.BaseAWSServiceIT;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,7 +12,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.times;

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/SecretsManagerDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/SecretsManagerDiscoveryIT.java
@@ -1,0 +1,70 @@
+package io.openraven.magpie.plugins.aws.discovery.services;
+
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.plugins.aws.discovery.AWSUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class SecretsManagerDiscoveryIT extends BaseAWSServiceIT {
+
+  private final String secretName = "TestSecret";
+  private static final String CF_SECRET_TEMPLATE_PATH = "/template/secret-template.yml";
+  private SecretsManagerDiscovery secretsManagerDiscovery = new SecretsManagerDiscovery();
+
+  @Mock
+  private Emitter emitter;
+
+  @Captor
+  private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
+
+  @BeforeAll
+  public static void setup() {
+    updateStackWithResources(CF_SECRET_TEMPLATE_PATH);
+  }
+
+  @Test
+  public void testSecretManagerDiscovery() {
+    // when
+    secretsManagerDiscovery.discover(
+      MAPPER,
+      SESSION,
+      BASE_REGION,
+      emitter,
+      LOGGER,
+      ACCOUNT
+    );
+
+    // then
+    Mockito.verify(emitter).emit(envelopeCapture.capture());
+    var contents = envelopeCapture.getValue().getContents();
+
+    assertNotNull(contents.get("documentId"));
+    assertTrue(contents.get("arn").asText().contains("secret:TestSecret"));
+    assertEquals(secretName, contents.get("resourceName").asText());
+    assertEquals("AWS::SecretsManager", contents.get("resourceType").asText());
+    assertEquals("account", contents.get("awsAccountId").asText());
+    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
+
+    assertEquals("[{\"key\":\"AppName\",\"value\":\"OpenRavenIT\"}]",
+      contents.get("configuration").get("tags").toString());
+  }
+
+  private void createSecret(SecretsManagerClient client) {
+    client.createSecret(req -> req
+      .name("TestSecret")
+      .secretString("{\"username\":\"TestUser\",\"password\":\"secret-password\"}"));
+  }
+}

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/SecretsManagerDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/SecretsManagerDiscoveryIT.java
@@ -2,7 +2,7 @@ package io.openraven.magpie.plugins.aws.discovery.services;
 
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieEnvelope;
-import io.openraven.magpie.plugins.aws.discovery.AWSUtils;
+import io.openraven.magpie.plugins.aws.discovery.services.base.BaseAWSServiceIT;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,11 +11,8 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 public class SecretsManagerDiscoveryIT extends BaseAWSServiceIT {
@@ -55,16 +52,10 @@ public class SecretsManagerDiscoveryIT extends BaseAWSServiceIT {
     assertTrue(contents.get("arn").asText().contains("secret:TestSecret"));
     assertEquals(secretName, contents.get("resourceName").asText());
     assertEquals("AWS::SecretsManager", contents.get("resourceType").asText());
-    assertEquals("account", contents.get("awsAccountId").asText());
+    assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
     assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
 
     assertEquals("[{\"key\":\"AppName\",\"value\":\"OpenRavenIT\"}]",
       contents.get("configuration").get("tags").toString());
-  }
-
-  private void createSecret(SecretsManagerClient client) {
-    client.createSecret(req -> req
-      .name("TestSecret")
-      .secretString("{\"username\":\"TestUser\",\"password\":\"secret-password\"}"));
   }
 }

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/base/BaseIAMServiceIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/base/BaseIAMServiceIT.java
@@ -8,7 +8,7 @@ public abstract class BaseIAMServiceIT extends BaseAWSServiceIT {
 
   protected static final IamClient IAMCLIENT = AWSUtils.configure(IamClient.builder(), BASE_REGION);
 
-  protected static void removeRoles() {
+  protected static void removePolicies() {
     IAMCLIENT.listPolicies(req -> req.scope(PolicyScopeType.LOCAL))
       .policies().forEach(policy -> IAMCLIENT.deletePolicy(req -> req.policyArn(policy.arn())));
   }

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/base/BaseIAMServiceIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/base/BaseIAMServiceIT.java
@@ -1,0 +1,16 @@
+package io.openraven.magpie.plugins.aws.discovery.services.base;
+
+import io.openraven.magpie.plugins.aws.discovery.AWSUtils;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.model.PolicyScopeType;
+
+public abstract class BaseIAMServiceIT extends BaseAWSServiceIT {
+
+  protected static final IamClient IAMCLIENT = AWSUtils.configure(IamClient.builder(), BASE_REGION);
+
+  protected static void removeRoles() {
+    IAMCLIENT.listPolicies(req -> req.scope(PolicyScopeType.LOCAL))
+      .policies().forEach(policy -> IAMCLIENT.deletePolicy(req -> req.policyArn(policy.arn())));
+  }
+
+}

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/disabled/CloudWatchDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/disabled/CloudWatchDiscoveryIT.java
@@ -1,0 +1,89 @@
+package io.openraven.magpie.plugins.aws.discovery.services.disabled;
+
+import io.openraven.magpie.api.Emitter;
+import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.plugins.aws.discovery.AWSUtils;
+import io.openraven.magpie.plugins.aws.discovery.services.CloudWatchDiscovery;
+import io.openraven.magpie.plugins.aws.discovery.services.base.BaseAWSServiceIT;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.*;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Disabled // Alarm history is not implemented - localstack 0.12.12. Unable to execute discovery.
+@ExtendWith(MockitoExtension.class)
+public class CloudWatchDiscoveryIT extends BaseAWSServiceIT {
+
+  private static final String CF_CLOUDWATCH_TEMPLATE_PATH = "/template/cloudwatch-template.yml";
+  private CloudWatchDiscovery cloudWatchDiscovery = new CloudWatchDiscovery();
+
+  @Mock
+  private Emitter emitter;
+
+  @Captor
+  private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
+
+  @BeforeAll
+  public static void setup() {
+    updateStackWithResources(CF_CLOUDWATCH_TEMPLATE_PATH);
+  }
+
+  @Test
+  public void testCloudWatchDiscovery() {
+    createAlarm();
+
+    cloudWatchDiscovery.discover(
+      MAPPER,
+      SESSION,
+      BASE_REGION,
+      emitter,
+      LOGGER,
+      ACCOUNT
+    );
+
+    // then
+    Mockito.verify(emitter).emit(envelopeCapture.capture());
+    var contents = envelopeCapture.getValue().getContents();
+
+    assertNotNull(contents.get("documentId"));
+  }
+
+  private void createAlarm() {
+    CloudWatchClient client = AWSUtils.configure(CloudWatchClient.builder(), BASE_REGION);
+
+    Dimension dimension = Dimension.builder()
+      .name("InstanceId")
+      .value("instanceid").build();
+
+    String testalarm = "testalarm";
+    PutMetricAlarmRequest request = PutMetricAlarmRequest.builder()
+      .alarmName(testalarm)
+      .comparisonOperator(
+        ComparisonOperator.GREATER_THAN_THRESHOLD)
+      .evaluationPeriods(1)
+      .metricName("CPUUtilization")
+      .namespace("AWS/EC2")
+      .period(60)
+      .statistic(Statistic.AVERAGE)
+      .threshold(70.0)
+      .actionsEnabled(false)
+      .alarmDescription(
+        "Alarm when server CPU utilization exceeds 70%")
+      .unit(StandardUnit.SECONDS)
+      .dimensions(dimension)
+      .build();
+
+    client.putMetricAlarm(request);
+  }
+
+
+}

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/disabled/KMSDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/disabled/KMSDiscoveryIT.java
@@ -1,9 +1,11 @@
-package io.openraven.magpie.plugins.aws.discovery.services;
+package io.openraven.magpie.plugins.aws.discovery.services.disabled;
 
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.plugins.aws.discovery.services.KMSDiscovery;
 import io.openraven.magpie.plugins.aws.discovery.services.base.BaseAWSServiceIT;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -11,15 +13,15 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import static org.junit.jupiter.api.Assertions.*;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Disabled // listKeyPolicies are failing on current version of localstack 0.12.12 (code 501)
 @ExtendWith(MockitoExtension.class)
-class S3DiscoveryIT extends BaseAWSServiceIT {
+public class KMSDiscoveryIT extends BaseAWSServiceIT {
 
-  private static final String BUCKET_NAME = "testbucket";
-  private static final String CF_S3_TEMPLATE_PATH = "/template/s3-template.yml";
-
-  private final S3Discovery s3Discovery = new S3Discovery();
+  private static final String CF_KMS_TEMPLATE_PATH = "/template/kms-template.yml";
+  private KMSDiscovery kmsDiscovery = new KMSDiscovery();
 
   @Mock
   private Emitter emitter;
@@ -29,14 +31,12 @@ class S3DiscoveryIT extends BaseAWSServiceIT {
 
   @BeforeAll
   public static void setup() {
-    // given
-    updateStackWithResources(CF_S3_TEMPLATE_PATH);
+    updateStackWithResources(CF_KMS_TEMPLATE_PATH);
   }
 
   @Test
-  public void testS3Discovery() {
-    // when
-    s3Discovery.discover(
+  public void testKMSDiscovery() {
+    kmsDiscovery.discover(
       MAPPER,
       SESSION,
       BASE_REGION,
@@ -50,13 +50,6 @@ class S3DiscoveryIT extends BaseAWSServiceIT {
     var contents = envelopeCapture.getValue().getContents();
 
     assertNotNull(contents.get("documentId"));
-    assertEquals("arn:aws:s3:::testbucket", contents.get("arn").asText());
-    assertEquals(BUCKET_NAME, contents.get("resourceName").asText());
-    assertEquals("AWS::S3::Bucket", contents.get("resourceType").asText());
-    assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
-    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
   }
+
 }
-
-
-

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/disabled/RedshiftDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/disabled/RedshiftDiscoveryIT.java
@@ -1,9 +1,11 @@
-package io.openraven.magpie.plugins.aws.discovery.services;
+package io.openraven.magpie.plugins.aws.discovery.services.disabled;
 
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieEnvelope;
+import io.openraven.magpie.plugins.aws.discovery.services.RedshiftDiscovery;
 import io.openraven.magpie.plugins.aws.discovery.services.base.BaseAWSServiceIT;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -11,15 +13,15 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import static org.junit.jupiter.api.Assertions.*;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Disabled // Disabled for current latest version of localstack 0.12.12. Not implemented yet
 @ExtendWith(MockitoExtension.class)
-class S3DiscoveryIT extends BaseAWSServiceIT {
+public class RedshiftDiscoveryIT extends BaseAWSServiceIT {
 
-  private static final String BUCKET_NAME = "testbucket";
-  private static final String CF_S3_TEMPLATE_PATH = "/template/s3-template.yml";
-
-  private final S3Discovery s3Discovery = new S3Discovery();
+  private final static String CF_REDSHIFT_TEMPLATE_PATH = "/template/redshift-template.yml";
+  private final RedshiftDiscovery redshiftDiscovery = new RedshiftDiscovery();
 
   @Mock
   private Emitter emitter;
@@ -29,14 +31,13 @@ class S3DiscoveryIT extends BaseAWSServiceIT {
 
   @BeforeAll
   public static void setup() {
-    // given
-    updateStackWithResources(CF_S3_TEMPLATE_PATH);
+    updateStackWithResources(CF_REDSHIFT_TEMPLATE_PATH);
   }
 
-  @Test
-  public void testS3Discovery() {
+  @Test // NotImplementedError: The describe_storage action has not been implemented
+  public void testRedshiftDiscovery() {
     // when
-    s3Discovery.discover(
+    redshiftDiscovery.discover(
       MAPPER,
       SESSION,
       BASE_REGION,
@@ -50,13 +51,6 @@ class S3DiscoveryIT extends BaseAWSServiceIT {
     var contents = envelopeCapture.getValue().getContents();
 
     assertNotNull(contents.get("documentId"));
-    assertEquals("arn:aws:s3:::testbucket", contents.get("arn").asText());
-    assertEquals(BUCKET_NAME, contents.get("resourceName").asText());
-    assertEquals("AWS::S3::Bucket", contents.get("resourceType").asText());
-    assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
-    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
   }
+
 }
-
-
-

--- a/magpie-aws/src/test/resources/demo/docker-compose.yml
+++ b/magpie-aws/src/test/resources/demo/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.8"
+
+services:
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    image: localstack/localstack:latest
+    ports:
+      - "4566:4566"
+      - "4571:4571"
+      - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
+    environment:
+      - SERVICES=dynamodb,s3,cloudformation,iam,sns
+      - DEBUG=1
+      - DATA_DIR=${DATA_DIR- }
+      - PORT_WEB_UI=${PORT_WEB_UI- }
+      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
+      - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - HOST_TMP_FOLDER=${TMPDIR}
+      - DEFAULT_REGION=us-west-1
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    networks:
+      - localstack_network
+networks:
+  localstack_network:

--- a/magpie-aws/src/test/resources/demo/docker-compose.yml
+++ b/magpie-aws/src/test/resources/demo/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "4571:4571"
       - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
     environment:
-      - SERVICES=dynamodb,s3,cloudformation,iam,sns
+      - SERVICES=dynamodb,s3,cloudformation,iam,sns,route53,redshift,lambda,ec2,kms,secretsmanager
       - DEBUG=1
       - DATA_DIR=${DATA_DIR- }
       - PORT_WEB_UI=${PORT_WEB_UI- }

--- a/magpie-aws/src/test/resources/demo/template/iam-s3-dynamo-template.yml
+++ b/magpie-aws/src/test/resources/demo/template/iam-s3-dynamo-template.yml
@@ -1,0 +1,72 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A sample template for creating a stack with a bucket and a DynamoDB table.
+Resources:
+  S3BucketForPoc:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: testbucket
+  DynamoDBTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: entities
+      AttributeDefinitions:
+        -
+          AttributeName: "pk"
+          AttributeType: "S"
+      KeySchema:
+        -
+          AttributeName: "pk"
+          KeyType: "HASH"
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5
+  TestUserEric:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: userA
+      Path: "/"
+      LoginProfile:
+        Password: P@ssW0rdEric
+  TestUserKevin:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: userB
+      Path: "/"
+      LoginProfile:
+        Password: P@ssW0rdKevin
+
+
+
+
+
+
+
+#      Policies:
+#        - PolicyName: giveaccesstoqueueonly
+#          PolicyDocument:
+#            Version: '2012-10-17'
+#            Statement:
+#              - Effect: Allow
+#                Action:
+#                  - sqs:*
+#                Resource:
+#                  - !GetAtt myqueue.Arn
+#              - Effect: Deny
+#                Action:
+#                  - sqs:*
+#                NotResource:
+#                  - !GetAtt myqueue.Arn
+#        - PolicyName: giveaccesstotopiconly
+#          PolicyDocument:
+#            Version: '2012-10-17'
+#            Statement:
+#              - Effect: Allow
+#                Action:
+#                  - sns:*
+#                Resource:
+#                  - !Ref mytopic
+#              - Effect: Deny
+#                Action:
+#                  - sns:*
+#                NotResource:
+#                  - !Ref mytopic

--- a/magpie-aws/src/test/resources/demo/template/sample/role-base.yml
+++ b/magpie-aws/src/test/resources/demo/template/sample/role-base.yml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "The Policy and InstanceProfile resources are specified externally to the IAM Role.
+They refer to the role by specifying its name, 'RootRole', in their respective Roles properties".
+Resources:
+  RootRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              Service:
+                - "ec2.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+  RolePolicies:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "root"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action: "*"
+            Resource: "*"
+      Roles:
+        - Ref: "RootRole"
+  RootInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Path: "/"
+      Roles:
+        - Ref: "RootRole"

--- a/magpie-aws/src/test/resources/document/policy-dynamodb-access.json
+++ b/magpie-aws/src/test/resources/document/policy-dynamodb-access.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+   {
+       "Effect": "Allow",
+       "Action": [
+           "dynamodb:DeleteItem",
+           "dynamodb:GetItem",
+           "dynamodb:PutItem",
+           "dynamodb:Scan",
+           "dynamodb:UpdateItem"
+      ],
+      "Resource": "*"
+   }
+  ]
+}

--- a/magpie-aws/src/test/resources/document/policy-dynamodb-inline.json
+++ b/magpie-aws/src/test/resources/document/policy-dynamodb-inline.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+   {
+       "Effect": "Deny",
+       "Action": [
+           "dynamodb:DeleteItem",
+           "dynamodb:GetItem"
+      ],
+      "Resource": "*"
+   }
+  ]
+}

--- a/magpie-aws/src/test/resources/document/policy-dynamodb-updated-access.json
+++ b/magpie-aws/src/test/resources/document/policy-dynamodb-updated-access.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+   {
+       "Effect": "Deny",
+       "Action": [
+           "dynamodb:GetItem",
+           "dynamodb:PutItem"
+      ],
+      "Resource": "*"
+   }
+  ]
+}

--- a/magpie-aws/src/test/resources/logback-test.xml
+++ b/magpie-aws/src/test/resources/logback-test.xml
@@ -1,0 +1,34 @@
+<configuration>
+
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+
+  <!-- turn suppress all bug warnings from AWS wire protocol -->
+  <logger name="software.amazon.awssdk" level="WARN"/>
+  <logger name="software.amazon.awssdk.request" level="WARN"/>
+  <logger name="org.apache.http" level="WARN"/>
+  <logger name="com.datastax" level="ERROR"/>
+  <logger name="io.netty" level="WARN"/>
+
+  <!-- suppress all but warnings from kafka -->
+  <logger name="org.apache.kafka" level="warn"/>
+  <logger name="org.apache.zookeeper" level="warn"/>
+  <logger name="org.apache.curator" level="warn"/>
+
+  <root level="info">
+    <appender-ref ref="STDERR" />
+  </root>
+</configuration>

--- a/magpie-aws/src/test/resources/template/cloudwatch-template.yml
+++ b/magpie-aws/src/test/resources/template/cloudwatch-template.yml
@@ -1,0 +1,28 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  LambdaInvocationsAnomalyDetector:
+    Type: AWS::CloudWatch::AnomalyDetector
+    Properties:
+      MetricName: Invocations
+      Namespace: AWS/Lambda
+      Stat: Sum
+
+  LambdaInvocationsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Lambda invocations
+      AlarmName: LambdaInvocationsAlarm
+      ComparisonOperator: LessThanLowerOrGreaterThanUpperThreshold
+      EvaluationPeriods: 1
+      Metrics:
+        - Expression: ANOMALY_DETECTION_BAND(m1, 2)
+          Id: ad1
+        - Id: m1
+          MetricStat:
+            Metric:
+              MetricName: Invocations
+              Namespace: AWS/Lambda
+            Period: !!int 86400
+            Stat: Sum
+      ThresholdMetricId: ad1
+      TreatMissingData: breaching

--- a/magpie-aws/src/test/resources/template/dynamo-db-template.yml
+++ b/magpie-aws/src/test/resources/template/dynamo-db-template.yml
@@ -1,5 +1,4 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: Test template for creating a stack with a DynamoDB table.
 Resources:
   DynamoDBTable:
     Type: AWS::DynamoDB::Table

--- a/magpie-aws/src/test/resources/template/dynamo-db-template.yml
+++ b/magpie-aws/src/test/resources/template/dynamo-db-template.yml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Test template for creating a stack with a DynamoDB table.
+Resources:
+  DynamoDBTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: entities
+      AttributeDefinitions:
+        -
+          AttributeName: "pk"
+          AttributeType: "S"
+      KeySchema:
+        -
+          AttributeName: "pk"
+          KeyType: "HASH"
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5

--- a/magpie-aws/src/test/resources/template/ec2-template.yml
+++ b/magpie-aws/src/test/resources/template/ec2-template.yml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  EC2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: "ami-79fd7eee"
+      KeyName: "testkey"
+      BlockDeviceMappings:
+        - DeviceName: "/dev/sdm"
+          Ebs:
+            VolumeType: "io1"
+            Iops: "200"
+            DeleteOnTermination: "false"
+            VolumeSize: "20"
+        - DeviceName: "/dev/sdk"
+          NoDevice: {}
+  MyEIP:
+    Type: AWS::EC2::EIP
+    Properties:
+      InstanceId: !Ref EC2Instance

--- a/magpie-aws/src/test/resources/template/empty-stack.yml
+++ b/magpie-aws/src/test/resources/template/empty-stack.yml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Empty stack for further test execute and resource allocation
+Conditions:
+  HasNot: !Equals [ 'true', 'false' ]
+# dummy (null) resource, never created
+Resources:
+  NullResource:
+    Type: 'Custom::NullResource'
+    Condition: HasNot
+Outputs:
+  ExportsStackName:
+    Value: !Ref 'AWS::StackName'
+    Export:
+      Name: !Sub 'ExportsStackName-${AWS::StackName}'

--- a/magpie-aws/src/test/resources/template/iam-group-template.yml
+++ b/magpie-aws/src/test/resources/template/iam-group-template.yml
@@ -1,0 +1,5 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Test template for creating a stack with a IAM Group and policies resources
+Resources:
+  CFNUserGroup:
+    Type: AWS::IAM::Group

--- a/magpie-aws/src/test/resources/template/iam-policy-template.yml
+++ b/magpie-aws/src/test/resources/template/iam-policy-template.yml
@@ -1,0 +1,29 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AccountManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: "accountAccessPolicy"
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowAllUsersToListAccounts
+            Effect: Allow
+            Action:
+              - iam:ListAccountAliases
+              - iam:ListUsers
+              - iam:GetAccountSummary
+            Resource: "*"
+  OlderAccountManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: "olderAccountAccessPolicy"
+      PolicyDocument:
+        Version: 2008-10-17
+        Statement:
+          - Sid: AllowAllUsersToListAccounts
+            Effect: Allow
+            Action:
+              - iam:ListUsers
+              - iam:GetAccountSummary
+            Resource: "*"

--- a/magpie-aws/src/test/resources/template/iam-role-template.yml
+++ b/magpie-aws/src/test/resources/template/iam-role-template.yml
@@ -1,0 +1,58 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AccountManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: "accountAccessPolicy"
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowAllUsersToListAccounts
+            Effect: Allow
+            Action:
+              - iam:ListAccountAliases
+              - iam:ListUsers
+              - iam:GetAccountSummary
+            Resource: "*"
+      Roles:
+        - Ref: "RootRole"
+  RootRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              Service:
+                - "ec2.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+      Policies:
+        - PolicyName: inlinePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: '*'
+                Resource: '*'
+  RolePolicies:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "secondInlinePolicy"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action: "*"
+            Resource: "*"
+      Roles:
+        - Ref: "RootRole"
+  RootInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Path: "/"
+      Roles:
+        - Ref: "RootRole"

--- a/magpie-aws/src/test/resources/template/iam-role-template.yml
+++ b/magpie-aws/src/test/resources/template/iam-role-template.yml
@@ -50,9 +50,4 @@ Resources:
             Resource: "*"
       Roles:
         - Ref: "RootRole"
-  RootInstanceProfile:
-    Type: "AWS::IAM::InstanceProfile"
-    Properties:
-      Path: "/"
-      Roles:
-        - Ref: "RootRole"
+

--- a/magpie-aws/src/test/resources/template/iam-template.yml
+++ b/magpie-aws/src/test/resources/template/iam-template.yml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Test template for creating a stack with a IAM resources
+Resources:
+  TestUserA:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: userA
+      Path: "/"
+      LoginProfile:
+        Password: myP@ssW0rdAs
+  TestUserB:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: userB
+      Path: "/"
+      LoginProfile:
+        Password: myP@ssW0rdB

--- a/magpie-aws/src/test/resources/template/kms-template.yml
+++ b/magpie-aws/src/test/resources/template/kms-template.yml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  akscmk:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: "Encrypt sensitive data"
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: key-default-1
+        Statement:
+          - Sid: "Allow administration of the key"
+            Effect: Allow
+            Principal:
+              AWS: "arn:aws:iam::1234567890:root"
+            Action:
+              - "kms:*"
+            Resource: "*"
+          - Sid: "Allow use of the key"
+            Effect: Allow
+            Principal:
+              AWS: 'arn:aws:iam::0987654321:user/devuser'
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+            Resource: "*"
+      Tags:
+        - Key: country
+          Value: india
+  KeyAlias:
+    Type: 'AWS::KMS::Alias'
+    Properties:
+      AliasName: alias/testcmk
+      TargetKeyId: !Ref akscmk

--- a/magpie-aws/src/test/resources/template/lambda-template.yml
+++ b/magpie-aws/src/test/resources/template/lambda-template.yml
@@ -1,0 +1,28 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  function:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: arn:aws:iam::123456789012:role/lambda-role
+      Code:
+        ZipFile: |
+          exports.handler = async (event) => {
+              console.log(JSON.stringify(event, null, 2));
+              const response = {
+                  statusCode: 200,
+                  body: JSON.stringify('Hello from Lambda!'),
+              };
+              return response;
+          };
+      Runtime: nodejs12.x
+      TracingConfig:
+        Mode: Active
+  s3Permission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt function.Arn
+      Action: lambda:InvokeFunction
+      Principal: s3.amazonaws.com
+      SourceAccount: !Ref 'AWS::AccountId'
+      SourceArn: !GetAtt bucket.Arn

--- a/magpie-aws/src/test/resources/template/redshift-template.yml
+++ b/magpie-aws/src/test/resources/template/redshift-template.yml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  TestCluster:
+    Type: "AWS::Redshift::Cluster"
+    Properties:
+      DBName: "testdb"
+      MasterUsername: "master"
+      MasterUserPassword: "password"
+      NodeType: "ds2.xlarge"
+      ClusterType: "single-node"
+      Tags:
+        - Key: foo
+          Value: bar

--- a/magpie-aws/src/test/resources/template/route53-template.yml
+++ b/magpie-aws/src/test/resources/template/route53-template.yml
@@ -1,0 +1,29 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  HealthCheck:
+    Type: 'AWS::Route53::HealthCheck'
+    Properties:
+      HealthCheckConfig:
+        IPAddress: 192.0.2.44
+        Port: 80
+        Type: HTTP
+        ResourcePath: '/example/index.html'
+        FullyQualifiedDomainName: example.com
+        RequestInterval: 30
+        FailureThreshold: 3
+      HealthCheckTags:
+        - Key: SampleKey1
+          Value: SampleValue1
+        - Key: SampleKey2
+          Value: SampleValue2
+  DNS:
+    Type: "AWS::Route53::HostedZone"
+    Properties:
+      HostedZoneConfig:
+        Comment: 'My hosted zone for example.com'
+      Name: 'example.com'
+      VPCs:
+        - VPCId: 'vpc-abcd1234'
+          VPCRegion: 'ap-northeast-1'
+        - VPCId: 'vpc-efgh5678'
+          VPCRegion: 'us-west-2'

--- a/magpie-aws/src/test/resources/template/s3-template.yml
+++ b/magpie-aws/src/test/resources/template/s3-template.yml
@@ -1,0 +1,7 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Test template for creating a stack with a s3 bucket
+Resources:
+  S3BucketForPoc:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: testbucket

--- a/magpie-aws/src/test/resources/template/secret-template.yml
+++ b/magpie-aws/src/test/resources/template/secret-template.yml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  TestSecret:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Name: TestSecret
+      Description: This secret has a hardcoded password in SecretString (use GenerateSecretString instead)
+      SecretString: '{"username":"TestUser","password":"secret-password"}'
+      Tags:
+        - Key: AppName
+          Value: OpenRavenIT
+  MySecretResourcePolicy:
+    Type: 'AWS::SecretsManager::ResourcePolicy'
+    Properties:
+      SecretId: !Ref TestSecret
+      ResourcePolicy:
+        Version: 2012-10-17
+        Statement:
+          - Resource: '*'
+            Action: 'secretsmanager:DeleteSecret'
+            Effect: Deny
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'

--- a/magpie-aws/src/test/resources/template/sns-subscription-template.yml
+++ b/magpie-aws/src/test/resources/template/sns-subscription-template.yml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  CarSalesTopic:
+    Type: 'AWS::SNS::Topic'
+    Properties:
+      TopicName: CarSalesTopic
+  SCMSubscription:
+    Type: 'AWS::SNS::Subscription'
+    Properties:
+      TopicArn: !Ref CarSalesTopic
+      Endpoint: 'test@openraven.com'
+      Protocol: https
+      DeliveryPolicy:
+        healthyRetryPolicy:
+          numRetries: 20
+          minDelayTarget: 10
+          maxDelayTarget: 30
+          numMinDelayRetries: 3
+          numMaxDelayRetries: 17
+          numNoDelayRetries: 0
+          backoffFunction: exponential


### PR DESCRIPTION
Preliminary code which expose the current problems during test containers setup

0) DynamoDB discovery is working, you could try it.

1) At the moment we are creating dependencies for our selves (clients), so that it becomes difficult to inject localstack clients into the code. We need to expose private methods. But that also not working. Even deeper we also create such dependancy (S3 discovery is not working due to that perspective)
Otherwise with current clients we are trying to reach the real AWS. 

   1.1. I'm thinking about lightweight ServiceDiscovery pattern, but we need to keep clients being configured for different Regions being requested (e.g DynamoDB_AWS_GLOBAL / DynamoDB_US_WEST_1 ) 

2) Seems like AWS Java SDK doesn't provide possibility to override AWS Endpoint globally for all clients [link](https://github.com/aws/aws-cli/issues/4454)

3) For a demo purpose we could setup localstack separately but we need to bypass localstack docker URL to reach it. Meanwhile there no possibility for that in code

Proposal:
We could create our AWS Clients based on env variable being passed on the stage of execution - > if nothing passed fallback to the default one - https://aws.amazon.com/

[To not merge yet]