### PR TITLE
Output stderr only if it's not empty

### DIFF
--- a/magpie-core/src/main/java/io/openraven/magpie/core/cspm/services/PolicyAcquisitionServiceImpl.java
+++ b/magpie-core/src/main/java/io/openraven/magpie/core/cspm/services/PolicyAcquisitionServiceImpl.java
@@ -194,7 +194,9 @@ public class PolicyAcquisitionServiceImpl implements PolicyAcquisitionService {
       String stderr = IOUtils.toString(process.getErrorStream(), Charset.defaultCharset());
 
       LOGGER.info("Standard output: {}", stdout);
-      LOGGER.info("Error output: {}", stderr);
+      if (!stderr.isEmpty()) {
+        LOGGER.info("Error output: {}", stderr);
+      }
 
       return stdout;
     } catch (IOException e) {


### PR DESCRIPTION
When stderr is emtpy, following line is a bit misleading - that lines bellow it are errors
`14:13:50.645 [main] INFO  i.o.m.c.c.s.PolicyAcquisitionServiceImpl - Error output:`


```
14:13:50.634 [main] INFO  i.o.m.c.c.s.PolicyAcquisitionServiceImpl - Successfully loaded policy: 74406460-05fb-4057-b646-f3f8c1e5d56f
14:13:50.636 [main] INFO  i.o.m.c.c.s.PolicyAcquisitionServiceImpl - Running git rev-parse HEAD
14:13:50.645 [main] INFO  i.o.m.c.c.s.PolicyAcquisitionServiceImpl - Standard output: c90004ba230143915145224e1c0f8c65c38f98a4

14:13:50.645 [main] INFO  i.o.m.c.c.s.PolicyAcquisitionServiceImpl - Error output: 
14:13:50.741 [main] INFO  i.o.m.c.c.s.PolicyAnalyzerServiceImpl - Analyzing policy - CIS Amazon Web Services Foundations
14:13:50.742 [main] INFO  i.o.m.c.c.s.PolicyAnalyzerServiceImpl - Rule not analyzed (manually controlled) - Avoid the use of the "root" account
