### PR TITLE
#210 - Fix S3 bucket policy document processing

### DIFF
--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/EC2DiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/EC2DiscoveryIT.java
@@ -81,7 +81,7 @@ public class EC2DiscoveryIT extends BaseAWSServiceIT {
   }
 
   private void assertSnapshot(List<ObjectNode> data) {
-    assertEquals(36, data.size());
+    assertTrue(30 < data.size()); // Avoid flaky tests with backups generation
     var contents = data.get(0);
 
     assertNotNull(contents.get("documentId"));
@@ -118,7 +118,7 @@ public class EC2DiscoveryIT extends BaseAWSServiceIT {
     assertEquals(1, attachments.size());
     var attachment = attachments.get(0);
     assertNotNull(attachment.get("attachTime").asText());
-    assertNotNull("/dev/sda1", attachment.get("device").asText());
+    assertEquals("/dev/sda1", attachment.get("device").asText());
     assertTrue(attachment.get("instanceId").asText().startsWith("i-"));
     assertTrue(attachment.get("volumeId").asText().startsWith("vol-"));
     assertEquals("attached", attachment.get("state").asText());


### PR DESCRIPTION
Now S3 policy document saved not as string but a part of the Json and allowed to be analysed:

```
{
   "isPublic":false,
   "versioning":{
      "status":null,
      "mfaDelete":null
   },
   "bucketPolicy":{
      "Version":"2012-10-17",
      "Statement":[
         {
            "Sid":"AWSConfigBucketPermissionsCheck",
            "Action":"s3:GetBucketAcl",
            "Effect":"Allow",
            "Resource":"arn:aws:s3:::config-723176279592-us-west-1",
            "Principal":{
               "Service":"config.amazonaws.com"
            }
         },
         {
            "Sid":"AWSConfigBucketDelivery",
            "Action":"s3:PutObject",
            "Effect":"Allow",
            "Resource":"arn:aws:s3:::config-723176279592-us-west-1/AWSLogs/723176279592/*",
            "Principal":{
               "Service":"config.amazonaws.com"
            }
         }
      ]
   },
   "isPublicByACL":false,
   "isPublicByPolicy":false,
   "bucketPolicyStatus":{
      "isPublic":false
   },
```