### PR TITLE
Backup Discovery Improvements

### DIFF
--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/BackupUtils.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/BackupUtils.java
@@ -15,20 +15,19 @@
  */
 package io.openraven.magpie.plugins.aws.discovery;
 
+import com.amazonaws.SdkClientException;
+import org.slf4j.Logger;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.backup.BackupClient;
 import software.amazon.awssdk.services.backup.model.BackupJob;
 import software.amazon.awssdk.services.backup.model.BackupJobState;
 import software.amazon.awssdk.services.backup.model.ListBackupJobsRequest;
-import software.amazon.awssdk.services.backup.model.ListBackupJobsResponse;
 
 import java.time.Instant;
 import java.time.Period;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -38,17 +37,31 @@ public class BackupUtils {
 
   private static final Period HISTORY = Period.ofDays(45);
 
-  public static List<BackupJob.Builder> listBackupJobs(String arn, Region region, MagpieAWSClientCreator clientCreator) {
-    List<BackupJob.Builder> jobs = new LinkedList<>();
-    try (final var client = clientCreator.apply(BackupClient.builder()).region(region).build()) {
-      final var builder = ListBackupJobsRequest.builder()
-        .byResourceArn(arn)
-        .byCreatedAfter(Instant.now().minus(HISTORY))
-        .maxResults(1000)
-        .byState(BackupJobState.COMPLETED);
-      final var result = client.listBackupJobsPaginator(builder.build());
-      result.forEach(response -> jobs.addAll(response.backupJobs().stream().map(BackupJob::toBuilder).collect(Collectors.toList())));
-      return jobs;
+  public static List<BackupJob.Builder> listBackupJobs(String arn, Region region, MagpieAWSClientCreator clientCreator, Logger logger) {
+    var retries = 5;
+    while (retries > 0) {
+      try {
+        List<BackupJob.Builder> jobs = new LinkedList<>();
+        try (final var client = clientCreator.apply(BackupClient.builder()).region(region).build()) {
+          final var builder = ListBackupJobsRequest.builder()
+            .byResourceArn(arn)
+            .byCreatedAfter(Instant.now().minus(HISTORY))
+            .maxResults(1000)
+            .byState(BackupJobState.COMPLETED);
+          final var result = client.listBackupJobsPaginator(builder.build());
+          result.forEach(response -> jobs.addAll(response.backupJobs().stream().map(BackupJob::toBuilder).collect(Collectors.toList())));
+          return jobs;
+        }
+      } catch (SdkClientException ex) {
+        retries --;
+
+        if (retries == 0) {
+          throw ex;
+        }
+
+        logger.info("Couldn't list backup jobs for {}, retrying {} more times", arn, retries);
+      }
     }
+    return List.of();
   }
 }

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/BackupUtils.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/BackupUtils.java
@@ -59,7 +59,7 @@ public class BackupUtils {
           throw ex;
         }
 
-        logger.info("Couldn't list backup jobs for {}, retrying {} more times", arn, retries);
+        logger.warn("Couldn't list backup jobs for {}, retrying {} more times", arn, retries);
       }
     }
     return List.of();

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/AWSDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/AWSDiscovery.java
@@ -42,8 +42,8 @@ public interface AWSDiscovery {
 
   void discover(ObjectMapper mapper, Session session, Region region, Emitter Emitter, Logger logger, String account, MagpieAWSClientCreator clientCreator);
 
-  default void discoverBackupJobs(String arn, Region region, MagpieAwsResource data, MagpieAWSClientCreator clientCreator) {
-    final var backups = BackupUtils.listBackupJobs(arn, region, clientCreator);
+  default void discoverBackupJobs(String arn, Region region, MagpieAwsResource data, MagpieAWSClientCreator clientCreator, Logger logger) {
+    final var backups = BackupUtils.listBackupJobs(arn, region, clientCreator, logger);
     AWSUtils.update(data.supplementaryConfiguration, Map.of("awsBackupJobs", backups));
   }
 

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/DynamoDbDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/DynamoDbDiscovery.java
@@ -63,7 +63,7 @@ public class DynamoDbDiscovery implements AWSDiscovery {
   public void discover(ObjectMapper mapper, Session session, Region region, Emitter emitter, Logger logger, String account, MagpieAWSClientCreator clientCreator) {
     try (final var client = clientCreator.apply(DynamoDbClient.builder()).build()) {
       discoverGlobalTables(mapper, session, region, emitter, client, account);
-      discoverTables(mapper, session, region, emitter, client, account, clientCreator);
+      discoverTables(mapper, session, region, emitter, client, account, clientCreator, logger);
     }
   }
 
@@ -89,7 +89,7 @@ public class DynamoDbDiscovery implements AWSDiscovery {
     }
   }
 
-  protected void discoverTables(ObjectMapper mapper, Session session, Region region, Emitter emitter, DynamoDbClient client, String account, MagpieAWSClientCreator clientCreator) {
+  protected void discoverTables(ObjectMapper mapper, Session session, Region region, Emitter emitter, DynamoDbClient client, String account, MagpieAWSClientCreator clientCreator, Logger logger) {
     final String RESOURCE_TYPE = DynamoDbTable.RESOURCE_TYPE;
 
     try {
@@ -108,7 +108,7 @@ public class DynamoDbDiscovery implements AWSDiscovery {
 
           discoverContinuousBackups(client, table, data);
           discoverTags(client, table, data, mapper);
-          discoverBackupJobs(table.tableArn(), region, data, clientCreator);
+          discoverBackupJobs(table.tableArn(), region, data, clientCreator, logger);
 
           emitter.emit(VersionedMagpieEnvelopeProvider.create(session, List.of(fullService() + ":table"), data.toJsonNode()));
       });

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EBDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EBDiscovery.java
@@ -79,7 +79,7 @@ public class EBDiscovery implements AWSDiscovery {
         discoverEnvironmentResources(client, environment, data);
         discoverEnvironmentManagedActions(client, environment, data);
         discoverTags(client, environment, data, mapper);
-        discoverBackupJobs(environment.environmentArn(), region, data, clientCreator);
+        discoverBackupJobs(environment.environmentArn(), region, data, clientCreator, logger);
 
         emitter.emit(VersionedMagpieEnvelopeProvider.create(session, List.of(fullService() + ":environment"), data.toJsonNode()));
       });

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EC2Discovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EC2Discovery.java
@@ -103,7 +103,7 @@ public class EC2Discovery implements AWSDiscovery {
               .build();
 
             massageInstanceTypeAndPublicIp(data, instance, mapper, region, RESOURCE_TYPE);
-            discoverBackupJobs(arn, region, data, clientCreator);
+            discoverBackupJobs(arn, region, data, clientCreator, logger);
             emitter.emit(VersionedMagpieEnvelopeProvider.create(session, List.of(fullService()), data.toJsonNode()));
           })));
     } catch (SdkServiceException | SdkClientException ex) {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EFSDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EFSDiscovery.java
@@ -71,7 +71,7 @@ public class EFSDiscovery implements AWSDiscovery {
           .build();
 
         discoverMountTargets(client, fileSystem, data);
-        discoverBackupJobs(arn, region, data, clientCreator);
+        discoverBackupJobs(arn, region, data, clientCreator, logger);
 
         emitter.emit(VersionedMagpieEnvelopeProvider.create(session, List.of(fullService() + ":fileSystem"), data.toJsonNode()));
       });

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/FSXDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/FSXDiscovery.java
@@ -69,7 +69,7 @@ public class FSXDiscovery implements AWSDiscovery {
           .build();
 
         discoverSize(fileSystem, data, region, logger, clientCreator);
-        discoverBackupJobs(fileSystem.resourceARN(), region, data, clientCreator);
+        discoverBackupJobs(fileSystem.resourceARN(), region, data, clientCreator, logger);
 
         emitter.emit(VersionedMagpieEnvelopeProvider.create(session, List.of(fullService() + ":fileSystem"), data.toJsonNode()));
       });

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/RDSDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/RDSDiscovery.java
@@ -120,7 +120,7 @@ public class RDSDiscovery implements AWSDiscovery {
           discoverInstanceDbSnapshots(client, db, data);
           discoverInstanceSize(db, data, logger, clientCreator);
 
-          discoverBackupJobs(db.dbInstanceArn(), region, data, clientCreator);
+          discoverBackupJobs(db.dbInstanceArn(), region, data, clientCreator, logger);
 
           emitter.emit(VersionedMagpieEnvelopeProvider.create(session, List.of(fullService() + ":dbInstance"), data.toJsonNode()));
         });

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/StorageGatewayDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/StorageGatewayDiscovery.java
@@ -68,7 +68,6 @@ public class StorageGatewayDiscovery implements AWSDiscovery {
           .build();
 
         discoverGatewayInfo(client, gateway, data);
-        discoverBackupJobs(gateway.gatewayARN(), region, data, clientCreator);
         emitter.emit(VersionedMagpieEnvelopeProvider.create(session, List.of(fullService() + ":gateway"), data.toJsonNode()));
       });
     } catch (SdkServiceException | SdkClientException ex) {

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/DynamoDbDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/DynamoDbDiscoveryIT.java
@@ -14,6 +14,8 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
@@ -28,7 +30,7 @@ class DynamoDbDiscoveryIT extends BaseAWSServiceIT {
 
   private final DynamoDbDiscovery dynamoDbDiscovery = new DynamoDbDiscovery() {
     // We override this to make it a no-op since we can't perform Backup calls on the free version of Localstack.
-    public void discoverBackupJobs(String arn, Region region, MagpieAwsResource data, MagpieAWSClientCreator clientCreator) {
+    public void discoverBackupJobs(String arn, Region region, MagpieAwsResource data, MagpieAWSClientCreator clientCreator, Logger logger) {
     }
   };
 
@@ -56,7 +58,8 @@ class DynamoDbDiscoveryIT extends BaseAWSServiceIT {
       emitter,
       dynamoDbClient,
       ACCOUNT,
-      ClientCreators.localClientCreator(BASE_REGION)
+      ClientCreators.localClientCreator(BASE_REGION),
+      LoggerFactory.getLogger(DynamoDbDiscoveryIT.class)
     );
 
     // then

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/EC2DiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/EC2DiscoveryIT.java
@@ -15,6 +15,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.regions.Region;
 
@@ -31,7 +32,7 @@ public class EC2DiscoveryIT extends BaseAWSServiceIT {
   private static final String CF_EC2_TEMPLATE_PATH = "/template/ec2-template.yml";
   private final EC2Discovery ec2Discovery = new EC2Discovery() {
     // We override this to make it a no-op since we can't perform Backup calls on the free version of Localstack.
-    public void discoverBackupJobs(String arn, Region region, MagpieAwsResource data, MagpieAWSClientCreator clientCreator) {
+    public void discoverBackupJobs(String arn, Region region, MagpieAwsResource data, MagpieAWSClientCreator clientCreator, Logger logger) {
     }
   };
 


### PR DESCRIPTION
* Added retry logic to backup list requests (5)
* Don't attempt to list backups for Storage Gateway (it's not supported via the API).

All ITs pass, and I can verify that backup discovery did not break.  The retry code remains largely untested until we try it  in our clusters.



┆Issue is synchronized with this [Jira Task](https://openraven.atlassian.net/browse/RAD-376) by [Unito](https://www.unito.io)
