### PR TITLE
Correct accessor, reuse sts client

### DIFF
--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryConfig.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryConfig.java
@@ -17,7 +17,6 @@
 package io.openraven.magpie.plugins.aws.discovery;
 
 import java.util.List;
-import java.util.Optional;
 
 public class AWSDiscoveryConfig {
   private List<String> assumedRoles = List.of();
@@ -63,8 +62,8 @@ public class AWSDiscoveryConfig {
     this.assumedRoles = assumedRoles;
   }
 
-  public Optional<String> getExternalId() {
-      return Optional.ofNullable(this.externalId);
+  public String getExternalId() {
+      return this.externalId;
   }
 
   public void setExternalId(String externalId) {

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryPlugin.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryPlugin.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -108,7 +109,7 @@ public class AWSDiscoveryPlugin implements OriginPlugin<AWSDiscoveryConfig> {
         enabledPlugins.forEach(plugin -> {
           final var regions = getRegionsForDiscovery(plugin);
           regions.forEach(region -> {
-            final var clientCreator = ClientCreators.assumeRoleCreator(region, role, config.getExternalId());
+            final var clientCreator = ClientCreators.assumeRoleCreator(region, role, Optional.ofNullable(config.getExternalId()));
             try (final var client = clientCreator.apply(StsClient.builder()).build()) {
               final String account = client.getCallerIdentity().account();
               logger.info("Discovering cross-account {}:{} using role {}", plugin.service(), region,   role);

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/ClientCreators.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/ClientCreators.java
@@ -12,6 +12,9 @@ import java.util.UUID;
 
 public class ClientCreators {
 
+  //This client does not need to be recreated on every request.
+  public static final StsClient stsClient = StsClient.create();
+
   public static MagpieAWSClientCreator assumeRoleCreator(final Region region, final String roleArn, Optional<String> externalIdOptional) {
     return new MagpieAWSClientCreator(){
       @Override
@@ -25,7 +28,7 @@ public class ClientCreators {
                   .roleSessionName(UUID.randomUUID().toString());
           externalIdOptional.ifPresent(assumeRoleRequestBuilder::externalId);
           final var provider = StsAssumeRoleCredentialsProvider.builder()
-          .stsClient(StsClient.create())
+          .stsClient(stsClient)
           .refreshRequest(
             assumeRoleRequestBuilder
               .build()


### PR DESCRIPTION
Apologies for the bug in !511. This corrects the api to now return a `String` instead of `Optional<String>`. Additionally, stsClients are reusable and the previous implementation was leaking them on every assume role request.

Verified in cluster.