### PR TITLE
Disble backup discovery for EB, add exception handling

### DIFF
--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EBDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EBDiscovery.java
@@ -79,7 +79,6 @@ public class EBDiscovery implements AWSDiscovery {
         discoverEnvironmentResources(client, environment, data);
         discoverEnvironmentManagedActions(client, environment, data);
         discoverTags(client, environment, data, mapper);
-        discoverBackupJobs(environment.environmentArn(), region, data, clientCreator, logger);
 
         emitter.emit(VersionedMagpieEnvelopeProvider.create(session, List.of(fullService() + ":environment"), data.toJsonNode()));
       });


### PR DESCRIPTION
BackupDiscovery now handles non sdk exceptions with telemetry and tolerance.

EBDiscovery no longer attempts to discover backup plans (these aren't supported in backup service).