### PR TITLE
Client closure and IT fix.

### DIFF
--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/EC2DiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/EC2DiscoveryIT.java
@@ -36,6 +36,12 @@ public class EC2DiscoveryIT extends BaseAWSServiceIT {
     }
   };
 
+  private final EC2StorageDiscovery ec2StorageDiscovery = new EC2StorageDiscovery() {
+    // We override this to make it a no-op since we can't perform Backup calls on the free version of Localstack.
+    public void discoverBackupJobs(String arn, Region region, MagpieAwsResource data, MagpieAWSClientCreator clientCreator, Logger logger) {
+    }
+  };
+
   @Mock
   private Emitter emitter;
 
@@ -65,6 +71,17 @@ public class EC2DiscoveryIT extends BaseAWSServiceIT {
 
     // when
     ec2Discovery.discover(
+      MAPPER,
+      SESSION,
+      BASE_REGION,
+      emitter,
+      LOGGER,
+      ACCOUNT,
+      ClientCreators.localClientCreator(BASE_REGION)
+    );
+
+    // when
+    ec2StorageDiscovery.discover(
       MAPPER,
       SESSION,
       BASE_REGION,

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMAccountDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMAccountDiscoveryIT.java
@@ -1,6 +1,7 @@
 package io.openraven.magpie.plugins.aws.discovery.services;
 
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieEnvelope;
 import io.openraven.magpie.plugins.aws.discovery.services.base.BaseIAMServiceIT;
@@ -30,7 +31,7 @@ public class IAMAccountDiscoveryIT extends BaseIAMServiceIT {
   private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
 
   @Test
-  public void testAccountDiscovery() {
+  public void testAccountDiscovery() throws JsonProcessingException {
     // given
     createAccountAliases(alias);
     createPasswordPolicy();
@@ -64,14 +65,14 @@ public class IAMAccountDiscoveryIT extends BaseIAMServiceIT {
       passwordPolicy.toString());
   }
 
-  private void assertAccount(MagpieEnvelope envelope) {
+  private void assertAccount(MagpieEnvelope envelope) throws JsonProcessingException {
     var contents = envelopeCapture.getValue().getContents();
+    System.out.println(MAPPER.writeValueAsString(contents));
     assertNotNull(contents.get("documentId").asText());
     assertEquals("arn:aws:organizations::account", contents.get("arn").asText());
     assertEquals(alias, contents.get("resourceName").asText());
     assertEquals("AWS::Account", contents.get("resourceType").asText());
     assertEquals(ACCOUNT, contents.get("awsAccountId").asText());
-    assertEquals(BASE_REGION.toString(), contents.get("awsRegion").asText());
   }
 
   private void createPasswordPolicy() {

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMAccountDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMAccountDiscoveryIT.java
@@ -31,7 +31,7 @@ public class IAMAccountDiscoveryIT extends BaseIAMServiceIT {
   private ArgumentCaptor<MagpieEnvelope> envelopeCapture;
 
   @Test
-  public void testAccountDiscovery() throws JsonProcessingException {
+  public void testAccountDiscovery() {
     // given
     createAccountAliases(alias);
     createPasswordPolicy();
@@ -65,9 +65,8 @@ public class IAMAccountDiscoveryIT extends BaseIAMServiceIT {
       passwordPolicy.toString());
   }
 
-  private void assertAccount(MagpieEnvelope envelope) throws JsonProcessingException {
+  private void assertAccount(MagpieEnvelope envelope) {
     var contents = envelopeCapture.getValue().getContents();
-    System.out.println(MAPPER.writeValueAsString(contents));
     assertNotNull(contents.get("documentId").asText());
     assertEquals("arn:aws:organizations::account", contents.get("arn").asText());
     assertEquals(alias, contents.get("resourceName").asText());

--- a/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMAccountDiscoveryIT.java
+++ b/magpie-aws/src/test/java/io/openraven/magpie/plugins/aws/discovery/services/IAMAccountDiscoveryIT.java
@@ -1,7 +1,6 @@
 package io.openraven.magpie.plugins.aws.discovery.services;
 
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieEnvelope;
 import io.openraven.magpie.plugins.aws.discovery.services.base.BaseIAMServiceIT;


### PR DESCRIPTION
Properly encapsulate the STS client in a try w/resources, and fix two failing ITs.

I removed the `awsRegion` check on the IT because account discovery does not send a region.  This looks intentional so I'm unsure why we tested for it.