### PR TITLE
[PROD-4002] We require a Runtime exception as the calling services th…

### DIFF
--- a/magpie-data/src/main/java/io/openraven/magpie/data/exception/MissingEntityTypeException.java
+++ b/magpie-data/src/main/java/io/openraven/magpie/data/exception/MissingEntityTypeException.java
@@ -1,11 +1,29 @@
+/*-
+ * #%L
+ * Magpie API
+ * %%
+ * Copyright (C) 2021 - 2022 Open Raven Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package io.openraven.magpie.data.exception;
 
-import java.io.IOException;
 
 /**
- * Signals that an I/O exception occurred due to an asset type being consumed that isn't supported by the library.
+ * Signals that an exception occurred due to an asset type being consumed that isn't supported by the library.
  */
-public class MissingEntityTypeException extends IOException {
+public class MissingEntityTypeException extends RuntimeException {
 
   /**
    * Constructs an {@code MissingEntityTypeException} with the specified detail message.

--- a/magpie-data/src/main/java/io/openraven/magpie/data/utils/EntityTypeResolver.java
+++ b/magpie-data/src/main/java/io/openraven/magpie/data/utils/EntityTypeResolver.java
@@ -90,7 +90,7 @@ public class EntityTypeResolver extends TypeIdResolverBase {
     }
 
     @Override
-    public JavaType typeFromId(DatabindContext context, String id) throws IOException {
+    public JavaType typeFromId(DatabindContext context, String id) throws MissingEntityTypeException {
         if (typeMap.containsKey(id)) {
             return context.constructSpecializedType(baseType, typeMap.get(id));
         }


### PR DESCRIPTION
…at need to catch MissingEntityTypeExceptions are unable to establish that it can be thrown as a checked Exception due to way the resolver is wired in to the Object Mapper.