### PR TITLE
Update sentry and other deps to more current for magpie/magpie-aws

### DIFF
--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -13,12 +13,12 @@
     <project.version>${project.version}</project.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <sentry.version>1.7.28</sentry.version>
+    <sentry.version>6.3.0</sentry.version>
     <javatuples.version>1.2</javatuples.version>
     <aws-sigv4-auth-cassandra-java-driver-plugin.version>4.0.3</aws-sigv4-auth-cassandra-java-driver-plugin.version>
-    <sentry.version>1.7.28</sentry.version>
-    <mockito.version>3.10.0</mockito.version>
-    <unirest-java.version>3.13.6</unirest-java.version>
+    <mockito.version>4.6.1</mockito.version>
+    <unirest-java.version>3.13.10</unirest-java.version>
+    <logback-classic.version>1.2.9</logback-classic.version>
   </properties>
 
   <dependencies>
@@ -38,11 +38,11 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
-      <dependency>
-          <groupId>software.amazon.awssdk</groupId>
-          <artifactId>sso</artifactId>
-          <version>${aws.sdk.version}</version>
-      </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sso</artifactId>
+      <version>${aws.sdk.version}</version>
+    </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>athena</artifactId>
@@ -297,7 +297,7 @@
     <dependency>
       <groupId>io.sentry</groupId>
       <artifactId>sentry</artifactId>
-      <version>1.7.28</version>
+      <version>${sentry.version}</version>
     </dependency>
 
     <!-- Test scope -->
@@ -309,7 +309,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
+      <version>${logback-classic.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <jackson.version>2.12.7</jackson.version>
     <testcontainer.version>1.16.2</testcontainer.version>
-    <aws.sdk.version>2.17.93</aws.sdk.version>
+    <aws.sdk.version>2.17.243</aws.sdk.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
Bumps sentry off the 1.X tag to the 6.X tag. Updates impacted exceptional handling code. Bumps aws sdk and some other dependencies that had drifted.