### PR TITLE
Add nascent injected credential provider support

### DIFF
--- a/magpie-core/src/main/java/io/openraven/magpie/core/plugins/PluginManager.java
+++ b/magpie-core/src/main/java/io/openraven/magpie/core/plugins/PluginManager.java
@@ -18,10 +18,7 @@ package io.openraven.magpie.core.plugins;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.openraven.magpie.api.OriginPlugin;
-import io.openraven.magpie.api.IntermediatePlugin;
 import io.openraven.magpie.api.MagpiePlugin;
-import io.openraven.magpie.api.TerminalPlugin;
 import io.openraven.magpie.core.config.ConfigException;
 import io.openraven.magpie.core.config.MagpieConfig;
 import org.slf4j.Logger;
@@ -110,7 +107,8 @@ public class PluginManager {
       }
     }
 
-    return MAPPER.treeToValue(MAPPER.valueToTree(config), configType);
+//    return MAPPER.treeToValue(MAPPER.valueToTree(config), configType);
+      return config;
   }
 
   public List<MagpiePlugin<?>> byType(Class<? extends MagpiePlugin> clazz) {

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/GCPDiscoveryConfig.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/GCPDiscoveryConfig.java
@@ -16,16 +16,39 @@
 
 package io.openraven.magpie.plugins.gcp.discovery;
 
+import com.google.api.gax.core.CredentialsProvider;
+
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 public class GCPDiscoveryConfig {
   private List<String> services = List.of();
 
-  public List<String> getServices() {
+    private CredentialsProvider credentialsProvider;
+    private Optional<Supplier<List<String>>> projectListProvider = Optional.empty();
+
+    public List<String> getServices() {
     return services;
   }
 
   public void setServices(List<String> services) {
     this.services = services == null ? List.of() : services;
   }
+
+    public CredentialsProvider getCredentialsProvider() {
+        return credentialsProvider;
+    }
+
+    public void setCredentialsProvider(CredentialsProvider credentialsProvider) {
+        this.credentialsProvider = credentialsProvider;
+    }
+
+    public Optional<Supplier<List<String>>> getProjectListProvider() {
+        return this.projectListProvider;
+    }
+
+    public void setProjectListProvider(Supplier<List<String>> projectListProvider) {
+        this.projectListProvider = Optional.ofNullable(projectListProvider);
+    }
 }

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/AssetDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/AssetDiscovery.java
@@ -17,20 +17,23 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.asset.v1.AssetServiceClient;
+import com.google.cloud.asset.v1.AssetServiceSettings;
 import com.google.cloud.asset.v1.ProjectName;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
 import io.openraven.magpie.api.Session;
 import io.openraven.magpie.data.gcp.asset.Asset;
 import io.openraven.magpie.data.gcp.asset.AssetFeed;
-import io.openraven.magpie.plugins.gcp.discovery.exception.DiscoveryExceptions;
 import io.openraven.magpie.plugins.gcp.discovery.GCPUtils;
 import io.openraven.magpie.plugins.gcp.discovery.VersionedMagpieEnvelopeProvider;
+import io.openraven.magpie.plugins.gcp.discovery.exception.DiscoveryExceptions;
 import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class AssetDiscovery implements GCPDiscovery {
   private static final String SERVICE = "asset";
@@ -40,8 +43,10 @@ public class AssetDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
-    try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
+    var builder = AssetServiceSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
+    try (AssetServiceClient assetServiceClient = AssetServiceClient.create(builder.build())) {
       discoverFeeds(mapper, projectId, session, emitter, assetServiceClient);
       discoverAssets(mapper, projectId, session, emitter, assetServiceClient);
     } catch (IOException e) {

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/BigQueryReservationDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/BigQueryReservationDiscovery.java
@@ -17,11 +17,13 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.appengine.repackaged.com.google.common.base.Pair;
 import com.google.cloud.bigquery.reservation.v1.Assignment;
 import com.google.cloud.bigquery.reservation.v1.LocationName;
 import com.google.cloud.bigquery.reservation.v1.Reservation;
 import com.google.cloud.bigquery.reservation.v1.ReservationServiceClient;
+import com.google.cloud.bigquery.reservation.v1.ReservationServiceSettings;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
 import io.openraven.magpie.api.Session;
@@ -35,6 +37,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class BigQueryReservationDiscovery implements GCPDiscovery {
   private static final String SERVICE = "bigQueryReservation";
@@ -73,8 +76,10 @@ public class BigQueryReservationDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
-    try (var client = ReservationServiceClient.create()) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
+    var builder =  ReservationServiceSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
+    try (var client = ReservationServiceClient.create(builder.build())) {
       discoverReservations(mapper, projectId, session, emitter, client);
       discoverCapacityCommitments(mapper, projectId, session, emitter, client);
     } catch (IOException e) {

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/BigTableDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/BigTableDiscovery.java
@@ -17,8 +17,10 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.appengine.repackaged.com.google.common.base.Pair;
 import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminSettings;
 import com.google.cloud.bigtable.admin.v2.models.Cluster;
 import com.google.cloud.bigtable.admin.v2.models.Instance;
 import com.google.cloud.bigtable.admin.v2.models.PartialListInstancesException;
@@ -34,6 +36,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class BigTableDiscovery implements GCPDiscovery {
   private static final String SERVICE = "bigTable";
@@ -43,10 +46,13 @@ public class BigTableDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = BigTableInstance.RESOURCE_TYPE;
+    var builder = BigtableInstanceAdminSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
+    builder.setProjectId(projectId);
 
-    try (BigtableInstanceAdminClient client = BigtableInstanceAdminClient.create(projectId)) {
+    try (BigtableInstanceAdminClient client = BigtableInstanceAdminClient.create(builder.build())) {
       List<Instance> instances = new ArrayList<>();
       try {
         instances = client.listInstances();

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/CloudBuildDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/CloudBuildDiscovery.java
@@ -17,7 +17,9 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.devtools.cloudbuild.v1.CloudBuildClient;
+import com.google.cloud.devtools.cloudbuild.v1.CloudBuildSettings;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
 import io.openraven.magpie.api.Session;
@@ -30,6 +32,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class CloudBuildDiscovery implements GCPDiscovery {
   private static final String SERVICE = "cloudBuild";
@@ -39,8 +42,10 @@ public class CloudBuildDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
-    try (CloudBuildClient cloudBuildClient = CloudBuildClient.create()) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
+    var builder = CloudBuildSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
+    try (CloudBuildClient cloudBuildClient = CloudBuildClient.create(builder.build())) {
       discoverBuildTriggers(mapper, projectId, session, emitter, cloudBuildClient);
       discoverBuilds(mapper, projectId, session, emitter, cloudBuildClient);
     } catch (IOException e) {

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ClusterDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ClusterDiscovery.java
@@ -17,7 +17,9 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.container.v1.ClusterManagerClient;
+import com.google.cloud.container.v1.ClusterManagerSettings;
 import com.google.container.v1.ListClustersResponse;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
@@ -30,6 +32,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class ClusterDiscovery implements GCPDiscovery {
   private static final String SERVICE = "cluster";
@@ -39,10 +42,12 @@ public class ClusterDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = Cluster.RESOURCE_TYPE;
+    var builder = ClusterManagerSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (ClusterManagerClient clusterManagerClient = ClusterManagerClient.create()) {
+    try (ClusterManagerClient clusterManagerClient = ClusterManagerClient.create(builder.build())) {
       ListClustersResponse response = clusterManagerClient.listClusters(
         String.format("projects/%s/locations/-", projectId));
 

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ContainerAnalysisDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ContainerAnalysisDiscovery.java
@@ -17,7 +17,9 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.devtools.containeranalysis.v1beta1.GrafeasV1Beta1Client;
+import com.google.cloud.devtools.containeranalysis.v1beta1.GrafeasV1Beta1Settings;
 import com.google.cloud.secretmanager.v1.ProjectName;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
@@ -31,6 +33,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class ContainerAnalysisDiscovery implements GCPDiscovery {
   private static final String SERVICE = "containerAnalysis";
@@ -40,8 +43,10 @@ public class ContainerAnalysisDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
-    try (var client = GrafeasV1Beta1Client.create()) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
+    var builder = GrafeasV1Beta1Settings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
+    try (var client = GrafeasV1Beta1Client.create(builder.build())) {
       discoverOccurrences(mapper, projectId, session, emitter, client);
       discoverNotes(mapper, projectId, session, emitter, client);
     } catch (IOException e) {

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/DataCatalogDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/DataCatalogDiscovery.java
@@ -17,9 +17,11 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.rpc.NotFoundException;
 import com.google.appengine.repackaged.com.google.common.base.Pair;
 import com.google.cloud.datacatalog.v1.DataCatalogClient;
+import com.google.cloud.datacatalog.v1.DataCatalogSettings;
 import com.google.cloud.datacatalog.v1.Entry;
 import com.google.cloud.datacatalog.v1.LocationName;
 import io.openraven.magpie.api.Emitter;
@@ -34,6 +36,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class DataCatalogDiscovery implements GCPDiscovery {
   private static final String SERVICE = "dataCatalog";
@@ -78,10 +81,12 @@ public class DataCatalogDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = DataCatalog.RESOURCE_TYPE;
+    var builder = DataCatalogSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (DataCatalogClient dataCatalogClient = DataCatalogClient.create()) {
+    try (DataCatalogClient dataCatalogClient = DataCatalogClient.create(builder.build())) {
       AVAILABLE_LOCATIONS.forEach(location -> {
         try {
           String parent = LocationName.of(projectId, location).toString();

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/DataLabelingDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/DataLabelingDiscovery.java
@@ -17,10 +17,12 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.appengine.repackaged.com.google.common.base.Pair;
 import com.google.cloud.datalabeling.v1beta1.AnnotatedDataset;
 import com.google.cloud.datalabeling.v1beta1.DataItem;
 import com.google.cloud.datalabeling.v1beta1.DataLabelingServiceClient;
+import com.google.cloud.datalabeling.v1beta1.DataLabelingServiceSettings;
 import com.google.cloud.datalabeling.v1beta1.Dataset;
 import com.google.cloud.secretmanager.v1.ProjectName;
 import io.openraven.magpie.api.Emitter;
@@ -37,6 +39,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class DataLabelingDiscovery implements GCPDiscovery {
   private static final String SERVICE = "dataLabeling";
@@ -46,8 +49,10 @@ public class DataLabelingDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
-    try (DataLabelingServiceClient dataLabelingServiceClient = DataLabelingServiceClient.create()) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
+    var builder = DataLabelingServiceSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
+    try (DataLabelingServiceClient dataLabelingServiceClient = DataLabelingServiceClient.create(builder.build())) {
       discoverDatasets(mapper, projectId, session, emitter, dataLabelingServiceClient);
       discoverInstructions(mapper, projectId, session, emitter, dataLabelingServiceClient);
       discoverAnnotationSpecSet(mapper, projectId, session, emitter, dataLabelingServiceClient);

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/DlpDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/DlpDiscovery.java
@@ -17,7 +17,9 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.cloud.dlp.v2.DlpServiceSettings;
 import com.google.privacy.dlp.v2.ProjectName;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
@@ -31,6 +33,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class DlpDiscovery implements GCPDiscovery {
   private static final String SERVICE = "dlp";
@@ -40,8 +43,10 @@ public class DlpDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
-    try (DlpServiceClient dlpServiceClient = DlpServiceClient.create()) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
+    var builder = DlpServiceSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
+    try (DlpServiceClient dlpServiceClient = DlpServiceClient.create(builder.build())) {
       discoverJobTrigger(mapper, projectId, session, emitter, dlpServiceClient);
       discoverDlpJobs(mapper, projectId, session, emitter, dlpServiceClient);
     } catch (IOException e) {

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/FunctionsDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/FunctionsDiscovery.java
@@ -17,7 +17,9 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.functions.v1.CloudFunctionsServiceClient;
+import com.google.cloud.functions.v1.CloudFunctionsServiceSettings;
 import com.google.cloud.functions.v1.ListFunctionsRequest;
 import com.google.cloud.functions.v1.LocationName;
 import io.openraven.magpie.api.Emitter;
@@ -31,6 +33,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class FunctionsDiscovery implements GCPDiscovery {
   private static final String SERVICE = "functions";
@@ -40,10 +43,12 @@ public class FunctionsDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = Function.RESOURCE_TYPE;
+    var builder = CloudFunctionsServiceSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (CloudFunctionsServiceClient clusterManagerClient = CloudFunctionsServiceClient.create()) {
+    try (CloudFunctionsServiceClient clusterManagerClient = CloudFunctionsServiceClient.create(builder.build())) {
       var response = clusterManagerClient.listFunctions(
         ListFunctionsRequest.newBuilder().
           setParent(LocationName.of(projectId, "-").toString())

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/GCPDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/GCPDiscovery.java
@@ -17,21 +17,24 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.Session;
 import io.openraven.magpie.plugins.gcp.discovery.GCPDiscoveryPlugin;
 import org.slf4j.Logger;
 
+import java.util.Optional;
+
 public interface GCPDiscovery {
   String service();
 
-  default void discoverWrapper(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  default void discoverWrapper(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     logger.debug("Starting {} discovery ", service());
-    discover(mapper, projectId, session, emitter, logger);
+    discover(mapper, projectId, session, emitter, logger, maybeCredentialsProvider);
     logger.debug("Completed {} discovery", service());
   }
 
-  void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger);
+  void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider);
 
   default String fullService() {
     return GCPDiscoveryPlugin.ID + ":" + service();

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/GameServicesDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/GameServicesDiscovery.java
@@ -17,9 +17,11 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.rpc.UnimplementedException;
 import com.google.cloud.gaming.v1alpha.GameServerDeploymentsServiceClient;
 import com.google.cloud.gaming.v1alpha.RealmsServiceClient;
+import com.google.cloud.gaming.v1alpha.RealmsServiceSettings;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
 import io.openraven.magpie.api.Session;
@@ -31,6 +33,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class GameServicesDiscovery implements GCPDiscovery {
   private static final String SERVICE = "gameServices";
@@ -40,10 +43,12 @@ public class GameServicesDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = GameService.RESOURCE_TYPE;
+    var builder = RealmsServiceSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (var realmsServiceClient = RealmsServiceClient.create()) {
+    try (var realmsServiceClient = RealmsServiceClient.create(builder.build())) {
       String formattedParent = GameServerDeploymentsServiceClient.formatLocationName(projectId, "global");
 
       for (var realm : realmsServiceClient.listRealms(formattedParent).iterateAll()) {

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/IoTDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/IoTDiscovery.java
@@ -17,6 +17,7 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.appengine.repackaged.com.google.common.base.Pair;
 import com.google.cloud.iot.v1.*;
 import io.openraven.magpie.api.Emitter;
@@ -31,6 +32,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class IoTDiscovery implements GCPDiscovery {
   private static final String SERVICE = "iot";
@@ -42,10 +44,12 @@ public class IoTDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = IotDeviceRegistry.RESOURCE_TYPE;
+    var builder = DeviceManagerSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (DeviceManagerClient deviceManagerClient = DeviceManagerClient.create()) {
+    try (DeviceManagerClient deviceManagerClient = DeviceManagerClient.create(builder.build())) {
       AVAILABLE_LOCATIONS.forEach(location -> {
         String parent = LocationName.of(projectId, location).toString();
 

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/KMSDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/KMSDiscovery.java
@@ -17,9 +17,11 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.appengine.repackaged.com.google.common.base.Pair;
 import com.google.cloud.kms.v1.CryptoKey;
 import com.google.cloud.kms.v1.KeyManagementServiceClient;
+import com.google.cloud.kms.v1.KeyManagementServiceSettings;
 import com.google.cloud.kms.v1.LocationName;
 import com.google.iam.v1.Policy;
 import io.openraven.magpie.api.Emitter;
@@ -34,6 +36,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class KMSDiscovery implements GCPDiscovery {
   private static final String SERVICE = "kms";
@@ -86,9 +89,11 @@ public class KMSDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = KmsKeyring.RESOURCE_TYPE;
-    try (KeyManagementServiceClient keyManagementServiceClient = KeyManagementServiceClient.create()) {
+    var builder = KeyManagementServiceSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
+    try (KeyManagementServiceClient keyManagementServiceClient = KeyManagementServiceClient.create(builder.build())) {
       AVAILABLE_LOCATIONS.forEach(location -> {
         String parent = LocationName.of(projectId, location).toString();
 

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/MemcacheDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/MemcacheDiscovery.java
@@ -17,7 +17,9 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.memcache.v1.CloudMemcacheClient;
+import com.google.cloud.memcache.v1.CloudMemcacheSettings;
 import com.google.cloud.memcache.v1.LocationName;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
@@ -30,6 +32,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class MemcacheDiscovery implements GCPDiscovery {
   private static final String SERVICE = "memcache";
@@ -39,10 +42,12 @@ public class MemcacheDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = MemcacheInstance.RESOURCE_TYPE;
+    var builder = CloudMemcacheSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (CloudMemcacheClient cloudMemcacheClient = CloudMemcacheClient.create()) {
+    try (CloudMemcacheClient cloudMemcacheClient = CloudMemcacheClient.create(builder.build())) {
       String parent = LocationName.of(projectId, "-").toString();
       cloudMemcacheClient.listInstances(parent).iterateAll()
         .forEach(element -> {

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/MonitoringDashboardDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/MonitoringDashboardDiscovery.java
@@ -17,7 +17,9 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.monitoring.dashboard.v1.DashboardsServiceClient;
+import com.google.cloud.monitoring.dashboard.v1.DashboardsServiceSettings;
 import com.google.cloud.secretmanager.v1.ProjectName;
 import com.google.monitoring.dashboard.v1.ListDashboardsRequest;
 import io.openraven.magpie.api.Emitter;
@@ -31,6 +33,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class MonitoringDashboardDiscovery implements GCPDiscovery {
   private static final String SERVICE = "monitoringDashboard";
@@ -40,10 +43,12 @@ public class MonitoringDashboardDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = MonitoringDashboard.RESOURCE_TYPE;
+    var builder = DashboardsServiceSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (DashboardsServiceClient dashboardsServiceClient = DashboardsServiceClient.create()) {
+    try (DashboardsServiceClient dashboardsServiceClient = DashboardsServiceClient.create(builder.build())) {
       var request = ListDashboardsRequest.newBuilder()
         .setParent(ProjectName.of(projectId).toString())
         .build();

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/OsConfigDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/OsConfigDiscovery.java
@@ -17,8 +17,10 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.appengine.repackaged.com.google.common.base.Pair;
 import com.google.cloud.osconfig.v1.OsConfigServiceClient;
+import com.google.cloud.osconfig.v1.OsConfigServiceSettings;
 import com.google.cloud.osconfig.v1.PatchJobs;
 import com.google.cloud.osconfig.v1.ProjectName;
 import io.openraven.magpie.api.Emitter;
@@ -34,6 +36,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class OsConfigDiscovery implements GCPDiscovery {
   private static final String SERVICE = "osConfig";
@@ -43,8 +46,10 @@ public class OsConfigDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
-    try (OsConfigServiceClient client = OsConfigServiceClient.create()) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
+    var builder = OsConfigServiceSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
+    try (OsConfigServiceClient client = OsConfigServiceClient.create(builder.build())) {
       discoverPatchJobs(mapper, projectId, session, emitter, client);
       discoverPatchDeployments(mapper, projectId, session, emitter, client);
     } catch (IOException e) {

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ProjectDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ProjectDiscovery.java
@@ -1,8 +1,10 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.compute.v1.Project;
 import com.google.cloud.compute.v1.ProjectClient;
+import com.google.cloud.compute.v1.ProjectSettings;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
 import io.openraven.magpie.api.Session;
@@ -13,6 +15,7 @@ import io.openraven.magpie.plugins.gcp.discovery.exception.DiscoveryExceptions;
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.Optional;
 
 public class ProjectDiscovery implements GCPDiscovery {
   private static final String SERVICE = "project";
@@ -24,10 +27,11 @@ public class ProjectDiscovery implements GCPDiscovery {
   }
 
   @Override
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = ProjectInfo.RESOURCE_TYPE;
-
-    try (ProjectClient projectClient = ProjectClient.create()) {
+    var builder = ProjectSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
+    try (ProjectClient projectClient = ProjectClient.create(builder.build())) {
       Project project = projectClient.getProject(projectId);
 
       String assetId = "project::%s";

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/PubSubLiteDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/PubSubLiteDiscovery.java
@@ -17,9 +17,11 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.rpc.UnimplementedException;
 import com.google.cloud.pubsublite.proto.LocationName;
 import com.google.cloud.pubsublite.v1.AdminServiceClient;
+import com.google.cloud.pubsublite.v1.AdminServiceSettings;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
 import io.openraven.magpie.api.Session;
@@ -32,6 +34,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class PubSubLiteDiscovery implements GCPDiscovery {
   private static final String SERVICE = "pubSubLite";
@@ -41,8 +44,10 @@ public class PubSubLiteDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
-    try (var client =  AdminServiceClient.create()) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
+    var builder = AdminServiceSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
+    try (var client =  AdminServiceClient.create(builder.build())) {
       discoverSubscriptions(mapper, projectId, session, emitter, client);
       discoverTopic(mapper, projectId, session, emitter, client);
     } catch (IOException e) {

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/RecaptchaEnterpriseDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/RecaptchaEnterpriseDiscovery.java
@@ -17,7 +17,9 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.recaptchaenterprise.v1.RecaptchaEnterpriseServiceClient;
+import com.google.cloud.recaptchaenterprise.v1.RecaptchaEnterpriseServiceSettings;
 import com.google.recaptchaenterprise.v1.Key;
 import com.google.recaptchaenterprise.v1.ListKeysRequest;
 import com.google.recaptchaenterprise.v1.ProjectName;
@@ -32,6 +34,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class RecaptchaEnterpriseDiscovery implements GCPDiscovery {
   private static final String SERVICE = "recaptchaEnterprise";
@@ -41,11 +44,13 @@ public class RecaptchaEnterpriseDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = RecaptchaEnterpriseKey.RESOURCE_TYPE;
+    var builder = RecaptchaEnterpriseServiceSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
     try (RecaptchaEnterpriseServiceClient recaptchaEnterpriseServiceClient =
-           RecaptchaEnterpriseServiceClient.create()) {
+           RecaptchaEnterpriseServiceClient.create(builder.build())) {
       ListKeysRequest request =
         ListKeysRequest.newBuilder()
           .setParent(ProjectName.of(projectId).toString())

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/RedisDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/RedisDiscovery.java
@@ -17,7 +17,9 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.redis.v1.CloudRedisClient;
+import com.google.cloud.redis.v1.CloudRedisSettings;
 import com.google.cloud.redis.v1.LocationName;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
@@ -30,6 +32,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class RedisDiscovery implements GCPDiscovery {
   private static final String SERVICE = "redis";
@@ -39,10 +42,12 @@ public class RedisDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = RedisInstance.RESOURCE_TYPE;
+    var builder = CloudRedisSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+    try (CloudRedisClient cloudRedisClient = CloudRedisClient.create(builder.build())) {
       String parent = LocationName.of(projectId, "-").toString();
       cloudRedisClient.listInstances(parent).iterateAll()
         .forEach(element -> {

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/SchedulerDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/SchedulerDiscovery.java
@@ -17,7 +17,9 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.scheduler.v1beta1.CloudSchedulerClient;
+import com.google.cloud.scheduler.v1beta1.CloudSchedulerSettings;
 import com.google.cloud.scheduler.v1beta1.LocationName;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
@@ -30,6 +32,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class SchedulerDiscovery implements GCPDiscovery {
   private static final String SERVICE = "scheduler";
@@ -65,10 +68,12 @@ public class SchedulerDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = SchedulerJob.RESOURCE_TYPE;
+    var builder = CloudSchedulerSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (var cloudSchedulerClient = CloudSchedulerClient.create()) {
+    try (var cloudSchedulerClient = CloudSchedulerClient.create(builder.build())) {
       AVAILABLE_LOCATIONS.forEach(location -> {
         try {
           var parent = LocationName.of(projectId, location);

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ServiceDirectoryDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ServiceDirectoryDiscovery.java
@@ -17,11 +17,13 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.appengine.repackaged.com.google.common.base.Pair;
 import com.google.cloud.servicedirectory.v1.Endpoint;
 import com.google.cloud.servicedirectory.v1.LocationName;
 import com.google.cloud.servicedirectory.v1.Namespace;
 import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceSettings;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
 import io.openraven.magpie.api.Session;
@@ -34,6 +36,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class ServiceDirectoryDiscovery implements GCPDiscovery {
   private static final String SERVICE = "serviceDirectory";
@@ -76,10 +79,12 @@ public class ServiceDirectoryDiscovery implements GCPDiscovery {
   }
 
   @Override
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = Service.RESOURCE_TYPE;
+    var builder = RegistrationServiceSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create(builder.build())) {
       AVAILABLE_LOCATIONS.forEach(location -> {  // Discover services in all namespaces for all locations
         String parent = LocationName.of(projectId, location).toString();
 

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/TasksDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/TasksDiscovery.java
@@ -17,9 +17,11 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.appengine.repackaged.com.google.common.base.Pair;
 import com.google.cloud.iot.v1.LocationName;
 import com.google.cloud.tasks.v2.CloudTasksClient;
+import com.google.cloud.tasks.v2.CloudTasksSettings;
 import com.google.cloud.tasks.v2.Queue;
 import com.google.cloud.tasks.v2.Task;
 import io.openraven.magpie.api.Emitter;
@@ -34,6 +36,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class TasksDiscovery implements GCPDiscovery {
   private static final String SERVICE = "tasks";
@@ -75,10 +78,12 @@ public class TasksDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = TaskQueue.RESOURCE_TYPE;
+    var builder = CloudTasksSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (CloudTasksClient cloudTasksClient = CloudTasksClient.create()) {
+    try (CloudTasksClient cloudTasksClient = CloudTasksClient.create(builder.build())) {
       AVAILABLE_LOCATIONS.forEach(location -> {
         try {
           LocationName parent = LocationName.of(projectId, location);

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/TranslateDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/TranslateDiscovery.java
@@ -17,8 +17,10 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.translate.v3.LocationName;
 import com.google.cloud.translate.v3.TranslationServiceClient;
+import com.google.cloud.translate.v3.TranslationServiceSettings;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
 import io.openraven.magpie.api.Session;
@@ -30,6 +32,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class TranslateDiscovery implements GCPDiscovery {
   private static final String SERVICE = "`translate`";
@@ -41,10 +44,12 @@ public class TranslateDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = Glossary.RESOURCE_TYPE;
+    var builder = TranslationServiceSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (TranslationServiceClient translationServiceClient = TranslationServiceClient.create()) {
+    try (TranslationServiceClient translationServiceClient = TranslationServiceClient.create(builder.build())) {
       try {
         AVAILABLE_LOCATIONS.forEach(location -> {
           String parent = LocationName.of(projectId, location).toString();

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/VisionDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/VisionDiscovery.java
@@ -17,8 +17,10 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.vision.v1.LocationName;
 import com.google.cloud.vision.v1.ProductSearchClient;
+import com.google.cloud.vision.v1.ProductSearchSettings;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
 import io.openraven.magpie.api.Session;
@@ -31,6 +33,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class VisionDiscovery implements GCPDiscovery {
   private static final String SERVICE = "vision";
@@ -46,8 +49,10 @@ public class VisionDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
-    try (ProductSearchClient productSearchClient = ProductSearchClient.create()) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
+    var builder = ProductSearchSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
+    try (ProductSearchClient productSearchClient = ProductSearchClient.create(builder.build())) {
       AVAILABLE_LOCATIONS.forEach(location -> {
         discoverProducts(mapper, projectId, session, emitter, productSearchClient, location);
         discoverProductSets(mapper, projectId, session, emitter, productSearchClient, location);

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/WebSecurityScannerDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/WebSecurityScannerDiscovery.java
@@ -17,6 +17,7 @@
 package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.appengine.repackaged.com.google.common.base.Pair;
 import com.google.cloud.websecurityscanner.v1.*;
 import io.openraven.magpie.api.Emitter;
@@ -31,6 +32,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class WebSecurityScannerDiscovery implements GCPDiscovery {
   private static final String SERVICE = "webSecurityScanner";
@@ -40,10 +42,12 @@ public class WebSecurityScannerDiscovery implements GCPDiscovery {
     return SERVICE;
   }
 
-  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger) {
+  public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = WebSecurity.RESOURCE_TYPE;
+    var builder = WebSecurityScannerSettings.newBuilder();
+    maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (WebSecurityScannerClient webSecurityScannerClient = WebSecurityScannerClient.create()) {
+    try (WebSecurityScannerClient webSecurityScannerClient = WebSecurityScannerClient.create(builder.build())) {
       ListScanConfigsRequest request =
         ListScanConfigsRequest.newBuilder()
           .setParent(String.format("projects/%s", projectId))


### PR DESCRIPTION
This PR modifies the call chain for discover to add an injected google Credential Provider. This provider will supply credentials to a given discovery run for situations where the GOOGLE_APPLICATION_CREDENTIALS env var is not suitable for authentication.

Assigning to @kickroot and @tg0uld for triage? Apologies if incorrect.

I've tested iam discovery delivering to kafka configured in code.

I think the resourceType representation should be revisited. "GCP::Iam::Role" is mirroring the cloudformation notation used in AWS. That doesn't feel like a google resourceType, but an AWS resource type representing google (if you see my confusion). Since this PR already touches every discovery service, it is a timely moment to address this.

I belive @cwebberOps should be consulted. Also MD, but I can't seem to find his github handle.