### PR TITLE
Sentry Tweaks

### DIFF
--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -13,7 +13,6 @@
     <project.version>${project.version}</project.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <sentry.version>6.3.0</sentry.version>
     <javatuples.version>1.2</javatuples.version>
     <aws-sigv4-auth-cassandra-java-driver-plugin.version>4.0.3</aws-sigv4-auth-cassandra-java-driver-plugin.version>
     <mockito.version>4.6.1</mockito.version>

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryPlugin.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSDiscoveryPlugin.java
@@ -173,7 +173,11 @@ public class AWSDiscoveryPlugin implements OriginPlugin<AWSDiscoveryConfig> {
     this.logger = logger;
     this.config = config;
 
-    Sentry.init();
+    try {
+      Sentry.init();
+    } catch (IllegalArgumentException ex) {
+      logger.warn("Could not initialize Sentry: {}", ex.getMessage());
+    }
   }
 
   @Override

--- a/magpie-gcp/pom.xml
+++ b/magpie-gcp/pom.xml
@@ -13,7 +13,6 @@
     <project.version>0.1.0-SNAPSHOT</project.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <sentry.version>1.7.28</sentry.version>
     <javatuples.version>1.2</javatuples.version>
   </properties>
 
@@ -49,7 +48,7 @@
     <dependency>
       <groupId>io.sentry</groupId>
       <artifactId>sentry</artifactId>
-      <version>1.7.28</version>
+      <version>${sentry.version}</version>
     </dependency>
 
     <!-- Test scope -->

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/exception/DiscoveryExceptions.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/exception/DiscoveryExceptions.java
@@ -1,9 +1,9 @@
 package io.openraven.magpie.plugins.gcp.discovery.exception;
 
 import io.sentry.Sentry;
-import io.sentry.event.Event;
-import io.sentry.event.EventBuilder;
-import io.sentry.event.interfaces.ExceptionInterface;
+import io.sentry.SentryEvent;
+import io.sentry.SentryLevel;
+import io.sentry.protocol.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,10 +13,11 @@ public class DiscoveryExceptions {
 
   static public void onDiscoveryException(String resourceType, Exception ex) {
     logger.error("{} - Exception , with error {}", resourceType, ex.getMessage());
-    Sentry.capture(new EventBuilder().withMessage(resourceType + " Exception")
-      .withLevel(Event.Level.WARNING)
-      .withFingerprint(String.valueOf(resourceType), String.valueOf(ex.getMessage()))
-      .withExtra("Resource", String.valueOf(resourceType))
-      .withSentryInterface(new ExceptionInterface(ex)));
+    final var event = new SentryEvent();
+    event.setLevel(SentryLevel.WARNING);
+    final var message = new Message();
+    message.setMessage(resourceType + ":" + ex.getMessage());
+    event.setMessage(message);
+    Sentry.captureEvent(event);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <jackson.version>2.12.7</jackson.version>
     <testcontainer.version>1.16.2</testcontainer.version>
     <aws.sdk.version>2.17.243</aws.sdk.version>
+    <sentry.version>6.3.0</sentry.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
Update Sentry in the GCP plugin and standardize Sentry versions across Magpie.  Also make the use of SENTRY_DSN optional by catching the IAE.