### PR TITLE
PROD-5307

### DIFF
--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/IAMDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/IAMDiscovery.java
@@ -483,10 +483,10 @@ public class IAMDiscovery implements AWSDiscovery {
 
     for (int i = 1; i < reportLines.length; i++) {
       var credential = new IAMCredential(reportLines[i]);
-
-      var data = new MagpieAwsResource.MagpieAwsResourceBuilder(mapper, credential.arn)
+      final var synthetic_arn = credential.arn.concat(CREDENTIALS_REPORT);
+      var data = new MagpieAwsResource.MagpieAwsResourceBuilder(mapper, synthetic_arn)
         .withResourceName(credential.user)
-        .withResourceId(credential.arn.concat(CREDENTIALS_REPORT))
+        .withResourceId(synthetic_arn)
         .withResourceType(RESOURCE_TYPE)
         .withConfiguration(mapper.valueToTree(credential))
         .withAccountId(account)

--- a/magpie-core/src/main/java/io/openraven/magpie/core/plugins/PluginManager.java
+++ b/magpie-core/src/main/java/io/openraven/magpie/core/plugins/PluginManager.java
@@ -107,7 +107,11 @@ public class PluginManager {
       }
     }
 
-//    return MAPPER.treeToValue(MAPPER.valueToTree(config), configType);
+      // TODO: Investigate why the GCP Plugin doesn't require this line but AWS Discovery does.
+      if ("magpie.aws.discovery".equals(pluginId))  {
+        return MAPPER.treeToValue(MAPPER.valueToTree(config), configType);
+      }
+
       return config;
   }
 

--- a/magpie-core/src/main/java/io/openraven/magpie/core/plugins/PluginManager.java
+++ b/magpie-core/src/main/java/io/openraven/magpie/core/plugins/PluginManager.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openraven.magpie.api.MagpiePlugin;
 import io.openraven.magpie.core.config.ConfigException;
 import io.openraven.magpie.core.config.MagpieConfig;
+import org.python.google.common.collect.Lists;
+import org.python.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,8 +109,9 @@ public class PluginManager {
       }
     }
 
-      // TODO: Investigate why the GCP Plugin doesn't require this line but AWS Discovery does.
-      if ("magpie.aws.discovery".equals(pluginId))  {
+      // TODO: Investigate why the GCP Plugin doesn't require this line but AWS Discovery and the Persistence Plugin do.
+      final var pluginList = Sets.newHashSet("magpie.aws.discovery", "magpie.persist");
+      if (pluginList.contains(pluginId))  {
         return MAPPER.treeToValue(MAPPER.valueToTree(config), configType);
       }
 


### PR DESCRIPTION
Fix for PROD-5307, which requires the creation of a synthetic ARN to distinguish it from a User ARN, also temporarily fixed a config deserialization for AWS.