### PR TITLE
Bump gcp bom

### DIFF
--- a/magpie-api/pom.xml
+++ b/magpie-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.5.12-SNAPSHOT</version>
+    <version>0.5.13-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.5.12-SNAPSHOT</version>
+    <version>0.5.13-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <javatuples.version>1.2</javatuples.version>
-    <aws-sigv4-auth-cassandra-java-driver-plugin.version>4.0.3</aws-sigv4-auth-cassandra-java-driver-plugin.version>
+    <aws-sigv4-auth-cassandra-java-driver-plugin.version>4.0.8</aws-sigv4-auth-cassandra-java-driver-plugin.version>
     <mockito.version>4.6.1</mockito.version>
     <unirest-java.version>3.13.10</unirest-java.version>
     <logback-classic.version>1.2.9</logback-classic.version>

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/BackupUtils.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/BackupUtils.java
@@ -15,9 +15,9 @@
  */
 package io.openraven.magpie.plugins.aws.discovery;
 
-import com.amazonaws.SdkClientException;
 import io.openraven.magpie.data.aws.backup.BackupPlan;
 import org.slf4j.Logger;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.backup.BackupClient;
 import software.amazon.awssdk.services.backup.model.BackupJob;

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EC2Discovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/EC2Discovery.java
@@ -41,7 +41,6 @@ import io.sentry.protocol.Message;
 import kong.unirest.HttpResponse;
 import kong.unirest.HttpStatus;
 import kong.unirest.Unirest;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.net.util.SubnetUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.entity.ContentType;
@@ -54,6 +53,7 @@ import software.amazon.awssdk.services.ec2.model.DescribeNetworkAclsRequest;
 import software.amazon.awssdk.services.ec2.model.DescribeTransitGatewaysRequest;
 import software.amazon.awssdk.services.ec2.model.Instance;
 import software.amazon.awssdk.services.ec2.model.Tag;
+import software.amazon.awssdk.utils.StringUtils;
 
 import javax.annotation.Nullable;
 import java.io.IOException;

--- a/magpie-cli/pom.xml
+++ b/magpie-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.5.12-SNAPSHOT</version>
+    <version>0.5.13-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-core/pom.xml
+++ b/magpie-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.5.12-SNAPSHOT</version>
+    <version>0.5.13-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>io.openraven.magpie</groupId>
       <artifactId>magpie-persist</artifactId>
-      <version>0.5.12-SNAPSHOT</version>
+      <version>0.5.13-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/magpie-data/pom.xml
+++ b/magpie-data/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.5.12-SNAPSHOT</version>
+    <version>0.5.13-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-gcp/pom.xml
+++ b/magpie-gcp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.5.12-SNAPSHOT</version>
+    <version>0.5.13-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,6 +14,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <javatuples.version>1.2</javatuples.version>
+    <google-cloud-libraries.version>26.1.5</google-cloud-libraries.version>
   </properties>
 
   <dependencyManagement>
@@ -21,7 +22,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>20.6.0</version>
+        <version>${google-cloud-libraries.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/GCPUtils.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/GCPUtils.java
@@ -22,9 +22,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.appengine.repackaged.com.google.common.base.Pair;
-import com.google.appengine.repackaged.com.google.gson.GsonBuilder;
+import com.google.gson.GsonBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
 
 public class GCPUtils {
   private static final Logger logger = LoggerFactory.getLogger(GCPUtils.class);
@@ -33,6 +35,7 @@ public class GCPUtils {
   public  static ObjectMapper createObjectMapper() {
     return  new ObjectMapper()
       .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+      .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
       .findAndRegisterModules();
   }
 
@@ -51,5 +54,12 @@ public class GCPUtils {
   public static void update(JsonNode payload, Pair<String, Object> objectPair) {
     ObjectNode o = (ObjectNode) payload;
     o.set(objectPair.first, GCPUtils.asJsonNode(objectPair.second));
+  }
+
+  public static Instant protobufTimestampToInstant(com.google.protobuf.Timestamp timestamp) {
+    if (timestamp == null) {
+      return null;
+    }
+    return Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos());
   }
 }

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ErrorReportingDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ErrorReportingDiscovery.java
@@ -18,8 +18,8 @@ package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.gax.core.CredentialsProvider;
-import com.google.cloud.errorreporting.v1beta1.ErrorStatsServiceClient;
-import com.google.cloud.errorreporting.v1beta1.ErrorStatsServiceSettings;
+import com.google.devtools.clouderrorreporting.v1beta1.ErrorStatsServiceClient;
+import com.google.devtools.clouderrorreporting.v1beta1.ErrorStatsServiceSettings;
 import com.google.devtools.clouderrorreporting.v1beta1.ProjectName;
 import com.google.devtools.clouderrorreporting.v1beta1.QueryTimeRange;
 import io.openraven.magpie.api.Emitter;

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/FirewallDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/FirewallDiscovery.java
@@ -18,8 +18,8 @@ package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.gax.core.CredentialsProvider;
-import com.google.cloud.compute.v1.FirewallClient;
-import com.google.cloud.compute.v1.FirewallSettings;
+import com.google.cloud.compute.v1.FirewallsClient;
+import com.google.cloud.compute.v1.FirewallsSettings;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
 import io.openraven.magpie.api.Session;
@@ -44,11 +44,11 @@ public class FirewallDiscovery implements GCPDiscovery {
   @Override
   public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = Firewall.RESOURCE_TYPE;
-    var builder = FirewallSettings.newBuilder();
+    var builder = FirewallsSettings.newBuilder();
     maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
 
-    try (FirewallClient firewallClient = FirewallClient.create(builder.build())) {
-      firewallClient.listFirewalls(projectId).iterateAll().forEach(firewall -> {
+    try (FirewallsClient firewallClient = FirewallsClient.create(builder.build())) {
+      firewallClient.list(projectId).iterateAll().forEach(firewall -> {
         var data = new MagpieGcpResource.MagpieGcpResourceBuilder(mapper, firewall.getName())
           .withProjectId(projectId)
           .withResourceType(RESOURCE_TYPE)

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ProjectDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ProjectDiscovery.java
@@ -2,9 +2,10 @@ package io.openraven.magpie.plugins.gcp.discovery.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.gax.core.CredentialsProvider;
-import com.google.cloud.compute.v1.Project;
-import com.google.cloud.compute.v1.ProjectClient;
-import com.google.cloud.compute.v1.ProjectSettings;
+import com.google.cloud.resourcemanager.v3.Project;
+import com.google.cloud.resourcemanager.v3.ProjectName;
+import com.google.cloud.resourcemanager.v3.ProjectsClient;
+import com.google.cloud.resourcemanager.v3.ProjectsSettings;
 import io.openraven.magpie.api.Emitter;
 import io.openraven.magpie.api.MagpieGcpResource;
 import io.openraven.magpie.api.Session;
@@ -13,13 +14,18 @@ import io.openraven.magpie.plugins.gcp.discovery.GCPUtils;
 import io.openraven.magpie.plugins.gcp.discovery.VersionedMagpieEnvelopeProvider;
 import io.openraven.magpie.plugins.gcp.discovery.exception.DiscoveryExceptions;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.StreamSupport;
 
 public class ProjectDiscovery implements GCPDiscovery {
   private static final String SERVICE = "project";
-
+  private static final Logger LOGGER = LoggerFactory.getLogger(ProjectDiscovery.class);
+  public static final String ASSET_ID_FORMAT = "//cloudresourcemanager.googleapis.com/%s";
 
   @Override
   public String service() {
@@ -29,21 +35,61 @@ public class ProjectDiscovery implements GCPDiscovery {
   @Override
   public void discover(ObjectMapper mapper, String projectId, Session session, Emitter emitter, Logger logger, Optional<CredentialsProvider> maybeCredentialsProvider) {
     final String RESOURCE_TYPE = ProjectInfo.RESOURCE_TYPE;
-    var builder = ProjectSettings.newBuilder();
+    var builder = ProjectsSettings.newBuilder();
     maybeCredentialsProvider.ifPresent(builder::setCredentialsProvider);
-    try (ProjectClient projectClient = ProjectClient.create(builder.build())) {
-      Project project = projectClient.getProject(projectId);
+    try (ProjectsClient projectClient = ProjectsClient.create(builder.build())) {
+      // We have to use search because this API does not offer GET by Project ID, only by project name
+      String queryFormat = String.format("id:%s", projectId);
+      ProjectsClient.SearchProjectsPagedResponse resp = projectClient.searchProjects(queryFormat);
+      StreamSupport.stream(resp.iterateAll().spliterator(), false).filter(x -> projectId.equals(x.getProjectId()))
+        .findFirst()
+        .ifPresentOrElse(
+          (project) -> {
+            String assetId = String.format(ASSET_ID_FORMAT, ProjectName.format(projectId));
+            var data = new MagpieGcpResource.MagpieGcpResourceBuilder(mapper, assetId)
+              .withProjectId(projectId)
+              .withResourceId(projectId)
+              .withResourceName(project.getDisplayName())
+              .withResourceType(RESOURCE_TYPE)
+              .withConfiguration(GCPUtils.asJsonNode(new Configuration(project)))
+              .build();
 
-      String assetId = "project::%s";
-      var data = new MagpieGcpResource.MagpieGcpResourceBuilder(mapper, String.format(assetId, project.getName()))
-        .withProjectId(projectId)
-        .withResourceType(RESOURCE_TYPE)
-        .withConfiguration(GCPUtils.asJsonNode(project))
-        .build();
-
-      emitter.emit(VersionedMagpieEnvelopeProvider.create(session, List.of(fullService() + ":project"), data.toJsonNode()));
+            emitter.emit(VersionedMagpieEnvelopeProvider.create(session, List.of(fullService() + ":project"), data.toJsonNode()));
+          },
+          () -> LOGGER.error("Expected project id {} to exist, but could not find it", projectId)
+        );
     } catch (Exception e) {
       DiscoveryExceptions.onDiscoveryException(RESOURCE_TYPE, e);
+    }
+  }
+
+  // Based off of https://cloud.google.com/resource-manager/reference/rest/v3/projects#Project
+  // We need this because the model from GCP is not suitable for serialization
+  public static class Configuration {
+    public String name;
+    public String parent;
+    public String projectId;
+    public Project.State state;
+    public String displayName;
+    public Instant createTime;
+    public Instant updateTime;
+    public Instant deleteTime;
+    public String etag;
+    public Map<String, String> labels;
+
+    public Configuration() {}
+
+    public Configuration(Project project) {
+      this.name = project.getName();
+      this.parent = project.getParent();
+      this.projectId = project.getProjectId();
+      this.state = project.getState();
+      this.displayName = project.getDisplayName();
+      this.createTime = GCPUtils.protobufTimestampToInstant(project.getCreateTime());
+      this.updateTime = GCPUtils.protobufTimestampToInstant(project.getUpdateTime());
+      this.deleteTime = GCPUtils.protobufTimestampToInstant(project.getDeleteTime());
+      this.etag = project.getEtag();
+      this.labels = project.getLabelsMap();
     }
   }
 }

--- a/magpie-json/pom.xml
+++ b/magpie-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.5.12-SNAPSHOT</version>
+    <version>0.5.13-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-persist/pom.xml
+++ b/magpie-persist/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.5.12-SNAPSHOT</version>
+    <version>0.5.13-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-csv/pom.xml
+++ b/magpie-policy-output-csv/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.5.12-SNAPSHOT</version>
+    <version>0.5.13-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-json/pom.xml
+++ b/magpie-policy-output-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.5.12-SNAPSHOT</version>
+    <version>0.5.13-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-text/pom.xml
+++ b/magpie-policy-output-text/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.5.12-SNAPSHOT</version>
+    <version>0.5.13-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>io.openraven.magpie</groupId>
   <artifactId>magpie-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.5.12-SNAPSHOT</version>
+  <version>0.5.13-SNAPSHOT</version>
   <name>Open Raven Magpie</name>
   <url>https://github.com/openraven/magpie</url>
   <description>Open Raven's Magpie Project</description>


### PR DESCRIPTION
This PR:
1. Bumps BOM for GCP to a newer version. The current one was several major versions out of date which caused downstream issues in some projects
2. Discovers displayName for projects. Also fills in a lot of basic values like `resourceId` for project and Cloud Storage. Other resource types need to have more common fields filled out.
3. Cleans up the configuration JSON blobs in Cloud Storage and Projects. These had a lot of garbage values in them, things like `byte0: "..."` and even access tokens. In general, GCP's models are oftentimes not appropriate for serialization out of the box. We will need to check the other resource types and probably fix their configuration columns too.
4. Adjusts the `assetId` field for GCP Cloud Storage and Projects to be globally unique by using the concept "Resource Name" from GCP (not to be confused with our own `resourceName` field) which is their globally unique identifier.
5. Updates a dependency to help with some downstream dependencies.