### PR TITLE
Fixing RDS Discovery:

### DIFF
--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSUtils.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/AWSUtils.java
@@ -147,7 +147,7 @@ public class AWSUtils {
 
     GetMetricStatisticsResponse getMetricStatisticsResult = getCloudwatchMetricStatistics(regionID, namespace, metric, Statistic.MINIMUM, dimensions, clientCreator);
 
-    return Pair.with(getMetricStatisticsResult.datapoints().stream().map(Datapoint::maximum)
+    return Pair.with(getMetricStatisticsResult.datapoints().stream().map(Datapoint::minimum)
       .map(Double::longValue).max(Long::compareTo).orElse(null), getMetricStatisticsResult);
   }
 

--- a/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/RDSDiscovery.java
+++ b/magpie-aws/src/main/java/io/openraven/magpie/plugins/aws/discovery/services/RDSDiscovery.java
@@ -368,7 +368,7 @@ public class RDSDiscovery implements AWSDiscovery {
     Map<String, Object> requestMetrics = new HashMap<>();
     List<Dimension> dimensions = new ArrayList<>();
 
-    if (engine.equalsIgnoreCase("aurora-mysql")) {
+    if ("aurora-mysql".equalsIgnoreCase(engine)) {
       dimensions.add(Dimension.builder().name("DBClusterIdentifier").value(identifier).build());
       readMetric = "VolumeReadIOPs";
       writeMetric = "VolumeWriteIOPs";
@@ -397,7 +397,7 @@ public class RDSDiscovery implements AWSDiscovery {
   private void discoverCloudWatchClusterUsageMetrics(RdsClient client, DBCluster resource, MagpieAwsResource data, Logger logger, MagpieAWSClientCreator clientCreator) {
     try {
       Map<String, Object> allMetrics = new HashMap<>();
-      if (resource.engine().equalsIgnoreCase("aurora-mysql")) {
+      if ("aurora-mysql".equalsIgnoreCase(resource.engine())) {
         Map<String, Object> clusterMetrics = getRDSCloudWatchMetrics(resource.dbClusterIdentifier(), resource.engine(), data, logger, clientCreator);
         allMetrics.put(resource.dbClusterIdentifier() + ":cluster", clusterMetrics);
         AWSUtils.update(data.supplementaryConfiguration, Map.of("staleDataMetrics", allMetrics));


### PR DESCRIPTION
- Metrics were broken for particular types of RDS, specifically Aurora as it differs when it comes to CloudWatch metrics. Now accounts for all types and will be reflected in the StaleData service also.

- Any "cluster" will now only persist the cluster as one awsrdsdbinstance entry - the metadata of the instances within the cluster are stored in supplementaryConfiguration as it was with Aurora.

- Fixed broken FreeSpace metric for non-aurora instances.