### PR TITLE
Jn/gcp discovery improvements

### DIFF
--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/GCPUtils.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/GCPUtils.java
@@ -62,4 +62,14 @@ public class GCPUtils {
     }
     return Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos());
   }
+
+  public static String selfLinkToAssetId(String selfLink) {
+    return selfLink
+      .replaceFirst("https:", "")
+      .replaceFirst("/v1", "");
+  }
+
+  public static String assetNameToAssetId(String service, String projectId, String assetType, String assetName) {
+    return String.format("//%s.googleapis.com/projects/%s/%s/%s", service, projectId, assetType, assetName);
+  }
 }

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/BigQueryDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/BigQueryDiscovery.java
@@ -58,8 +58,12 @@ public class BigQueryDiscovery implements GCPDiscovery {
     final String RESOURCE_TYPE = BigQueryDataset.RESOURCE_TYPE;
     bigQuery.listDatasets(projectId).iterateAll()
       .forEach(datasetProxy -> {
+        // Big Query Self links are null for some reason?  We've got to manually construct the assetId
+        final var assetId = GCPUtils.assetNameToAssetId("bigquery", projectId, "datasets", datasetProxy.getDatasetId().getDataset());
         Dataset datasetModel = bigQuery.getDataset(datasetProxy.getDatasetId());
-        var data = new MagpieGcpResource.MagpieGcpResourceBuilder(mapper, datasetProxy.getGeneratedId())
+        var data = new MagpieGcpResource.MagpieGcpResourceBuilder(mapper, assetId)
+          .withResourceName(datasetProxy.getDatasetId().getDataset())
+          .withResourceId(assetId)
           .withProjectId(projectId)
           .withResourceType(RESOURCE_TYPE)
           .withConfiguration(GCPUtils.asJsonNode(datasetModel))

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/BigTableDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/BigTableDiscovery.java
@@ -38,6 +38,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static io.openraven.magpie.plugins.gcp.discovery.GCPUtils.assetNameToAssetId;
+
 public class BigTableDiscovery implements GCPDiscovery {
   private static final String SERVICE = "bigTable";
 
@@ -62,12 +64,14 @@ public class BigTableDiscovery implements GCPDiscovery {
       }
 
       instances.listIterator().forEachRemaining(instance -> {
-        var data = new MagpieGcpResource.MagpieGcpResourceBuilder(mapper, instance.getId())
+        final var assetId = assetNameToAssetId("bigtable", projectId, "instances", instance.getId());
+        var data = new MagpieGcpResource.MagpieGcpResourceBuilder(mapper, assetId)
+          .withResourceName(instance.getDisplayName())
+          .withResourceId(assetId)
           .withProjectId(projectId)
           .withResourceType(RESOURCE_TYPE)
           .withConfiguration(GCPUtils.asJsonNode(instance))
           .build();
-
         discoverClusters(client, instance, data);
 
         emitter.emit(VersionedMagpieEnvelopeProvider.create(session, List.of(fullService() + ":instance"), data.toJsonNode()));

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/SqlDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/SqlDiscovery.java
@@ -46,7 +46,10 @@ public class SqlDiscovery implements GCPDiscovery {
           continue;
         }
         for (var sqlInstance : response.getItems()) {
-          var data = new MagpieGcpResource.MagpieGcpResourceBuilder(mapper, sqlInstance.getName())
+          final var assetId = GCPUtils.selfLinkToAssetId(sqlInstance.getSelfLink());
+          var data = new MagpieGcpResource.MagpieGcpResourceBuilder(mapper, assetId)
+            .withResourceName(sqlInstance.getName())
+            .withResourceId(assetId)
             .withProjectId(projectId)
             .withResourceType(RESOURCE_TYPE)
             .withRegion(sqlInstance.getRegion())

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/StorageDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/StorageDiscovery.java
@@ -92,6 +92,7 @@ public class StorageDiscovery implements GCPDiscovery {
       ))
         .withProjectId(projectId)
         .withResourceId(bucket.getName())
+        .withResourceName(bucket.getName())
         .withResourceType(RESOURCE_TYPE)
         .withRegion(bucket.getLocation().toLowerCase())
         .withCreatedIso(bucket.getCreateTimeOffsetDateTime().toInstant())


### PR DESCRIPTION
Resolves PROD-8046
Resolves PROD-8041


Big Query:
```
 {
  "documentId" : "iQttP-XsPbGWGhNHVPk8Jw",
  "assetId" : "//bigquery.googleapis.com/projects/oss-discovery-test/datasets/oss_test_dataset",
  "resourceName" : "oss_test_dataset",
  "resourceId" : "//bigquery.googleapis.com/projects/oss-discovery-test/datasets/oss_test_dataset",
  "resourceType" : "GCP::BigQuery::Dataset",
...
}
```

Big Table:
```
 {
  "documentId" : "80tldNGTPUyMnk0LxhVs9w",
  "assetId" : "//bigtable.googleapis.com/projects/jason-758682/instances/jason-test-instance",
  "resourceName" : "jason-test-instance",
  "resourceId" : "//bigtable.googleapis.com/projects/jason-758682/instances/jason-test-instance",
  "resourceType" : "GCP::BigTable::Instance",
...
}
```

CloudSQL:
```
{
  "documentId" : "9hNMc5IdOtCsOGErA6OD8w",
  "assetId" : "//sqladmin.googleapis.com/projects/test-targets-347030/instances/cloud-sql-psql-inst",
  "resourceName" : "cloud-sql-psql-inst",
  "resourceId" : "//sqladmin.googleapis.com/projects/test-targets-347030/instances/cloud-sql-psql-inst",
  "resourceType" : "GCP::SQL::Instance",
  "region" : "us-west1",
...
}
```