### PR TITLE
PROD-8201 (Compute Engine Discovery OOM)

### DIFF
--- a/magpie-api/pom.xml
+++ b/magpie-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
+    <version>0.8.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-api/pom.xml
+++ b/magpie-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless-SNAPSHOT</version>
+    <version>0.8.3_diskless_logging-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-api/pom.xml
+++ b/magpie-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3-SNAPSHOT</version>
+    <version>0.8.3_diskless-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-api/pom.xml
+++ b/magpie-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless_logging-SNAPSHOT</version>
+    <version>0.8.3_compute_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-api/pom.xml
+++ b/magpie-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-json_test-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-api/pom.xml
+++ b/magpie-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_noop-SNAPSHOT</version>
+    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-api/pom.xml
+++ b/magpie-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-SNAPSHOT</version>
+    <version>0.8.4-json_test-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
+    <version>0.8.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless-SNAPSHOT</version>
+    <version>0.8.3_diskless_logging-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3-SNAPSHOT</version>
+    <version>0.8.3_diskless-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless_logging-SNAPSHOT</version>
+    <version>0.8.3_compute_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-json_test-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_noop-SNAPSHOT</version>
+    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-aws/pom.xml
+++ b/magpie-aws/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-SNAPSHOT</version>
+    <version>0.8.4-json_test-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-cli/pom.xml
+++ b/magpie-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
+    <version>0.8.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-cli/pom.xml
+++ b/magpie-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless-SNAPSHOT</version>
+    <version>0.8.3_diskless_logging-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-cli/pom.xml
+++ b/magpie-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3-SNAPSHOT</version>
+    <version>0.8.3_diskless-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-cli/pom.xml
+++ b/magpie-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless_logging-SNAPSHOT</version>
+    <version>0.8.3_compute_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-cli/pom.xml
+++ b/magpie-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-json_test-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-cli/pom.xml
+++ b/magpie-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_noop-SNAPSHOT</version>
+    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-cli/pom.xml
+++ b/magpie-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-SNAPSHOT</version>
+    <version>0.8.4-json_test-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-core/pom.xml
+++ b/magpie-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3-SNAPSHOT</version>
+    <version>0.8.3_diskless-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>io.openraven.magpie</groupId>
       <artifactId>magpie-persist</artifactId>
-      <version>0.8.3-SNAPSHOT</version>
+      <version>0.8.3_diskless-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/magpie-core/pom.xml
+++ b/magpie-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
+    <version>0.8.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>io.openraven.magpie</groupId>
       <artifactId>magpie-persist</artifactId>
-      <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
+      <version>0.8.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/magpie-core/pom.xml
+++ b/magpie-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless_logging-SNAPSHOT</version>
+    <version>0.8.3_compute_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>io.openraven.magpie</groupId>
       <artifactId>magpie-persist</artifactId>
-      <version>0.8.3_diskless_logging-SNAPSHOT</version>
+      <version>0.8.3_compute_noop-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/magpie-core/pom.xml
+++ b/magpie-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-SNAPSHOT</version>
+    <version>0.8.4-json_test-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>io.openraven.magpie</groupId>
       <artifactId>magpie-persist</artifactId>
-      <version>0.8.4-SNAPSHOT</version>
+      <version>0.8.4-json_test-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/magpie-core/pom.xml
+++ b/magpie-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless-SNAPSHOT</version>
+    <version>0.8.3_diskless_logging-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>io.openraven.magpie</groupId>
       <artifactId>magpie-persist</artifactId>
-      <version>0.8.3_diskless-SNAPSHOT</version>
+      <version>0.8.3_diskless_logging-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/magpie-core/pom.xml
+++ b/magpie-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-json_test-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>io.openraven.magpie</groupId>
       <artifactId>magpie-persist</artifactId>
-      <version>0.8.4-json_test-SNAPSHOT</version>
+      <version>0.9.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/magpie-core/pom.xml
+++ b/magpie-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_noop-SNAPSHOT</version>
+    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>io.openraven.magpie</groupId>
       <artifactId>magpie-persist</artifactId>
-      <version>0.8.3_compute_noop-SNAPSHOT</version>
+      <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/magpie-data/pom.xml
+++ b/magpie-data/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
+    <version>0.8.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-data/pom.xml
+++ b/magpie-data/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless-SNAPSHOT</version>
+    <version>0.8.3_diskless_logging-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-data/pom.xml
+++ b/magpie-data/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3-SNAPSHOT</version>
+    <version>0.8.3_diskless-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-data/pom.xml
+++ b/magpie-data/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless_logging-SNAPSHOT</version>
+    <version>0.8.3_compute_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-data/pom.xml
+++ b/magpie-data/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-json_test-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-data/pom.xml
+++ b/magpie-data/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_noop-SNAPSHOT</version>
+    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-data/pom.xml
+++ b/magpie-data/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-SNAPSHOT</version>
+    <version>0.8.4-json_test-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-gcp/pom.xml
+++ b/magpie-gcp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
+    <version>0.8.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-gcp/pom.xml
+++ b/magpie-gcp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless-SNAPSHOT</version>
+    <version>0.8.3_diskless_logging-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-gcp/pom.xml
+++ b/magpie-gcp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-SNAPSHOT</version>
+    <version>0.8.4-json_test-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -30,6 +30,11 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>3.24.4</version>
+    </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>

--- a/magpie-gcp/pom.xml
+++ b/magpie-gcp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3-SNAPSHOT</version>
+    <version>0.8.3_diskless-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-gcp/pom.xml
+++ b/magpie-gcp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless_logging-SNAPSHOT</version>
+    <version>0.8.3_compute_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-gcp/pom.xml
+++ b/magpie-gcp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-json_test-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-gcp/pom.xml
+++ b/magpie-gcp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_noop-SNAPSHOT</version>
+    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/GCPDiscoveryPlugin.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/GCPDiscoveryPlugin.java
@@ -153,7 +153,7 @@ public class GCPDiscoveryPlugin implements OriginPlugin<GCPDiscoveryConfig> {
           logger.debug("Discovering service: {}, class: {}", gcpDiscovery.service(), gcpDiscovery.getClass());
           gcpDiscovery.discoverWrapper(MAPPER, project, session, emitter, logger, Optional.ofNullable(config.getCredentialsProvider()));
         } catch (Exception ex) {
-          logger.error("Discovery error in service {} - {}", gcpDiscovery.service(), ex.getMessage());
+          logger.error("Discovery error for {} in service {} - {}", project, gcpDiscovery.service(), ex.getMessage());
           logger.debug("Details", ex);
         }
       }));

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/GCPUtils.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/GCPUtils.java
@@ -24,6 +24,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.appengine.repackaged.com.google.common.base.Pair;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,11 +46,22 @@ public class GCPUtils {
   }
 
   public static JsonNode asJsonNode(Object object) {
-    String jsonString = GSON.toJson(object);
+    String jsonString = new GsonBuilder().setPrettyPrinting().create().toJson(object);
 
     try {
       return mapper.readValue(jsonString, JsonNode.class);
     } catch (JsonProcessingException e) {
+      logger.error("Unexpected JsonProcessingException this shouldn't happen at all");
+    }
+
+    return mapper.createObjectNode();
+  }
+  public static JsonNode asJsonNode(AbstractMessage msg) {
+
+    try {
+      String jsonString = JsonFormat.printer().print(msg);
+      return mapper.readValue(jsonString, JsonNode.class);
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
       logger.error("Unexpected JsonProcessingException this shouldn't happen at all");
     }
 

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/GCPUtils.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/GCPUtils.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.appengine.repackaged.com.google.common.base.Pair;
+import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +33,8 @@ public class GCPUtils {
   private static final Logger logger = LoggerFactory.getLogger(GCPUtils.class);
   private static final ObjectMapper mapper = createObjectMapper();
 
+  private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
   public  static ObjectMapper createObjectMapper() {
     return  new ObjectMapper()
       .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
@@ -40,7 +43,7 @@ public class GCPUtils {
   }
 
   public static JsonNode asJsonNode(Object object) {
-    String jsonString = new GsonBuilder().setPrettyPrinting().create().toJson(object);
+    String jsonString = GSON.toJson(object);
 
     try {
       return mapper.readValue(jsonString, JsonNode.class);

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
@@ -61,11 +61,11 @@ public class ComputeEngineDiscovery implements GCPDiscovery {
       } catch (IOException e) {
         DiscoveryExceptions.onDiscoveryException("GCP::ComputeEngine::Instances", e);
       }
-      try {
-        discoverDisks(mapper, projectId, session, emitter, diskClient, zoneClient);
-      } catch (IOException e) {
-        DiscoveryExceptions.onDiscoveryException("GCP::ComputeEngine::Disk", e);
-      }
+//      try {
+//        discoverDisks(mapper, projectId, session, emitter, diskClient, zoneClient);
+//      } catch (IOException e) {
+//        DiscoveryExceptions.onDiscoveryException("GCP::ComputeEngine::Disk", e);
+//      }
     } catch (IOException e) {
       DiscoveryExceptions.onDiscoveryException("GCP::ComputeEngine::ClientAllocation", e);
     }

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
@@ -90,7 +90,7 @@ public class ComputeEngineDiscovery implements GCPDiscovery {
               .withProjectId(projectId)
               .withResourceType(RESOURCE_TYPE)
               .withRegion(zone.getName())
-//              .withConfiguration(GCPUtils.asJsonNode(instance))
+              .withConfiguration(GCPUtils.asJsonNode(instance))
               .build();
             emitter.emit(create(session, List.of(fullService() + ":instance"), data.toJsonNode()));
           }

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
@@ -57,12 +57,11 @@ public class ComputeEngineDiscovery implements GCPDiscovery {
          var instancesClient = InstancesClient.create(instancesSettings.build());
          var zoneClient = ZonesClient.create(zonesSettings.build())) {
       logger.debug("In discovery method for project={}", projectId);
-//      try {
-//
-//        discoverInstances(mapper, projectId, session, emitter, instancesClient, zoneClient, logger);
-//      } catch (IOException e) {
-//        DiscoveryExceptions.onDiscoveryException("GCP::ComputeEngine::Instances", e);
-//      }
+      try {
+        discoverInstances(mapper, projectId, session, emitter, instancesClient, zoneClient, logger);
+      } catch (IOException e) {
+        DiscoveryExceptions.onDiscoveryException("GCP::ComputeEngine::Instances", e);
+      }
 //      try {
 //        discoverDisks(mapper, projectId, session, emitter, diskClient, zoneClient);
 //      } catch (IOException e) {
@@ -91,7 +90,7 @@ public class ComputeEngineDiscovery implements GCPDiscovery {
               .withProjectId(projectId)
               .withResourceType(RESOURCE_TYPE)
               .withRegion(zone.getName())
-              .withConfiguration(GCPUtils.asJsonNode(instance))
+//              .withConfiguration(GCPUtils.asJsonNode(instance))
               .build();
             emitter.emit(create(session, List.of(fullService() + ":instance"), data.toJsonNode()));
           }

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import static io.openraven.magpie.plugins.gcp.discovery.VersionedMagpieEnvelopeProvider.create;
 
@@ -70,24 +71,17 @@ public class ComputeEngineDiscovery implements GCPDiscovery {
     }
   }
 
-  private void discoverInstances(
-    ObjectMapper mapper,
-    String projectId,
-    Session session,
-    Emitter emitter,
-    InstancesClient instancesClient,
-    ZonesClient zoneClient
-  ) throws IOException {
+  private void discoverInstances( ObjectMapper mapper, String projectId, Session session, Emitter emitter, InstancesClient instancesClient, ZonesClient zoneClient) throws IOException {
     final String RESOURCE_TYPE = ComputeInstance.RESOURCE_TYPE;
 
-
-      // On2 - we are listing all instances in all zones
       zoneClient.list(projectId).iterateAll().forEach(zone -> {
-
-        instancesClient.list(projectId, zone.getName()).iterateAll()
-          .forEach(instance -> {
-            String assetId = String.format("%s::%s", instance.getName(), instance.getId());
+        var pages = instancesClient.listPagedCallable().call(ListInstancesRequest.newBuilder().setProject(projectId).setZone(zone.getName()).build());
+        pages.iteratePages().forEach(p -> {
+          for (Instance instance : p.iterateAll()) {
+            String assetId = instanceSelfLinkToAssetId(instance.getSelfLink());
             var data = new MagpieGcpResource.MagpieGcpResourceBuilder(mapper, assetId)
+              .withResourceId(assetId)
+              .withResourceName(instance.getName())
               .withProjectId(projectId)
               .withResourceType(RESOURCE_TYPE)
               .withRegion(zone.getName())
@@ -95,8 +89,8 @@ public class ComputeEngineDiscovery implements GCPDiscovery {
               .build();
 
             emitter.emit(create(session, List.of(fullService() + ":instance"), data.toJsonNode()));
-          });
-
+          }
+        });
       });
   }
 
@@ -105,20 +99,41 @@ public class ComputeEngineDiscovery implements GCPDiscovery {
 
       // On2 - we are listing all disks in all zones
       zoneClient.list(projectId).iterateAll().forEach(zone -> {
-
-        diskClient.list(projectId, zone.getName()).iterateAll()
-          .forEach(disk -> {
-            String assetId = String.format("%s::%s", disk.getName(), disk.getId());
+        var disks = diskClient.listPagedCallable().call(ListDisksRequest.newBuilder().setProject(projectId).setZone(zone.getName()).build());
+        disks.iteratePages().forEach(p -> {
+          for (Disk disk : p.iterateAll()) {
+            String assetId = diskSelfLinkToAssetId(disk.getSelfLink());
             var data = new MagpieGcpResource.MagpieGcpResourceBuilder(mapper, assetId)
+              .withResourceId(assetId)
+              .withResourceName(disk.getName())
               .withProjectId(projectId)
               .withResourceType(RESOURCE_TYPE)
               .withRegion(zone.getName())
               .withConfiguration(GCPUtils.asJsonNode(disk))
               .build();
-
             emitter.emit(create(session, List.of(fullService() + ":disk"), data.toJsonNode()));
-          });
-
+          }
+        });
       });
+  }
+
+  private String instanceSelfLinkToAssetId(String selfLink) {
+    var matcher = Pattern.compile("https://.+?/compute/v\\d/projects/(.+?)/zones/(.+?)/instances/(.+)").matcher(selfLink);
+    if (matcher.find()) {
+      // project id, zone, instance ID
+      return String.format("//compute.googleapis.com/projects/%s/zones/%s/instances/%s", matcher.group(1), matcher.group(2), matcher.group(3));
+    } else {
+      throw new IllegalArgumentException("Invalid selfLink: " + selfLink);
     }
+  }
+
+  private String diskSelfLinkToAssetId(String selfLink) {
+    var matcher = Pattern.compile("https://.+?/compute/v\\d/projects/(.+?)/zones/(.+?)/disks/(.+)").matcher(selfLink);
+    if (matcher.find()) {
+      // project id, zone, instance ID
+      return String.format("//compute.googleapis.com/projects/%s/zones/%s/disks/%s", matcher.group(1), matcher.group(2), matcher.group(3));
+    } else {
+      throw new IllegalArgumentException("Invalid selfLink: " + selfLink);
+    }
+  }
 }

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
@@ -56,11 +56,13 @@ public class ComputeEngineDiscovery implements GCPDiscovery {
     try (var diskClient = DisksClient.create(diskSettings.build());
          var instancesClient = InstancesClient.create(instancesSettings.build());
          var zoneClient = ZonesClient.create(zonesSettings.build())) {
-      try {
-        discoverInstances(mapper, projectId, session, emitter, instancesClient, zoneClient, logger);
-      } catch (IOException e) {
-        DiscoveryExceptions.onDiscoveryException("GCP::ComputeEngine::Instances", e);
-      }
+      logger.debug("In discovery method for project={}", projectId);
+//      try {
+//
+//        discoverInstances(mapper, projectId, session, emitter, instancesClient, zoneClient, logger);
+//      } catch (IOException e) {
+//        DiscoveryExceptions.onDiscoveryException("GCP::ComputeEngine::Instances", e);
+//      }
 //      try {
 //        discoverDisks(mapper, projectId, session, emitter, diskClient, zoneClient);
 //      } catch (IOException e) {

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
@@ -87,7 +87,6 @@ public class ComputeEngineDiscovery implements GCPDiscovery {
               .withRegion(zone.getName())
               .withConfiguration(GCPUtils.asJsonNode(instance))
               .build();
-
             emitter.emit(create(session, List.of(fullService() + ":instance"), data.toJsonNode()));
           }
         });

--- a/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
+++ b/magpie-gcp/src/main/java/io/openraven/magpie/plugins/gcp/discovery/services/ComputeEngineDiscovery.java
@@ -62,11 +62,11 @@ public class ComputeEngineDiscovery implements GCPDiscovery {
       } catch (IOException e) {
         DiscoveryExceptions.onDiscoveryException("GCP::ComputeEngine::Instances", e);
       }
-//      try {
-//        discoverDisks(mapper, projectId, session, emitter, diskClient, zoneClient);
-//      } catch (IOException e) {
-//        DiscoveryExceptions.onDiscoveryException("GCP::ComputeEngine::Disk", e);
-//      }
+      try {
+        discoverDisks(mapper, projectId, session, emitter, diskClient, zoneClient);
+      } catch (IOException e) {
+        DiscoveryExceptions.onDiscoveryException("GCP::ComputeEngine::Disk", e);
+      }
     } catch (IOException e) {
       DiscoveryExceptions.onDiscoveryException("GCP::ComputeEngine::ClientAllocation", e);
     }

--- a/magpie-json/pom.xml
+++ b/magpie-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
+    <version>0.8.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-json/pom.xml
+++ b/magpie-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless-SNAPSHOT</version>
+    <version>0.8.3_diskless_logging-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-json/pom.xml
+++ b/magpie-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3-SNAPSHOT</version>
+    <version>0.8.3_diskless-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-json/pom.xml
+++ b/magpie-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless_logging-SNAPSHOT</version>
+    <version>0.8.3_compute_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-json/pom.xml
+++ b/magpie-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-json_test-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-json/pom.xml
+++ b/magpie-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_noop-SNAPSHOT</version>
+    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-json/pom.xml
+++ b/magpie-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-SNAPSHOT</version>
+    <version>0.8.4-json_test-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-persist/pom.xml
+++ b/magpie-persist/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
+    <version>0.8.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-persist/pom.xml
+++ b/magpie-persist/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless-SNAPSHOT</version>
+    <version>0.8.3_diskless_logging-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-persist/pom.xml
+++ b/magpie-persist/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3-SNAPSHOT</version>
+    <version>0.8.3_diskless-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-persist/pom.xml
+++ b/magpie-persist/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless_logging-SNAPSHOT</version>
+    <version>0.8.3_compute_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-persist/pom.xml
+++ b/magpie-persist/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-json_test-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-persist/pom.xml
+++ b/magpie-persist/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_noop-SNAPSHOT</version>
+    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-persist/pom.xml
+++ b/magpie-persist/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-SNAPSHOT</version>
+    <version>0.8.4-json_test-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-csv/pom.xml
+++ b/magpie-policy-output-csv/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
+    <version>0.8.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-csv/pom.xml
+++ b/magpie-policy-output-csv/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless-SNAPSHOT</version>
+    <version>0.8.3_diskless_logging-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-csv/pom.xml
+++ b/magpie-policy-output-csv/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3-SNAPSHOT</version>
+    <version>0.8.3_diskless-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-csv/pom.xml
+++ b/magpie-policy-output-csv/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless_logging-SNAPSHOT</version>
+    <version>0.8.3_compute_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-csv/pom.xml
+++ b/magpie-policy-output-csv/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-json_test-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-csv/pom.xml
+++ b/magpie-policy-output-csv/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_noop-SNAPSHOT</version>
+    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-csv/pom.xml
+++ b/magpie-policy-output-csv/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-SNAPSHOT</version>
+    <version>0.8.4-json_test-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-json/pom.xml
+++ b/magpie-policy-output-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
+    <version>0.8.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-json/pom.xml
+++ b/magpie-policy-output-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless-SNAPSHOT</version>
+    <version>0.8.3_diskless_logging-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-json/pom.xml
+++ b/magpie-policy-output-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3-SNAPSHOT</version>
+    <version>0.8.3_diskless-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-json/pom.xml
+++ b/magpie-policy-output-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless_logging-SNAPSHOT</version>
+    <version>0.8.3_compute_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-json/pom.xml
+++ b/magpie-policy-output-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-json_test-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-json/pom.xml
+++ b/magpie-policy-output-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_noop-SNAPSHOT</version>
+    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-json/pom.xml
+++ b/magpie-policy-output-json/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-SNAPSHOT</version>
+    <version>0.8.4-json_test-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-text/pom.xml
+++ b/magpie-policy-output-text/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
+    <version>0.8.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-text/pom.xml
+++ b/magpie-policy-output-text/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless-SNAPSHOT</version>
+    <version>0.8.3_diskless_logging-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-text/pom.xml
+++ b/magpie-policy-output-text/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3-SNAPSHOT</version>
+    <version>0.8.3_diskless-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-text/pom.xml
+++ b/magpie-policy-output-text/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_diskless_logging-SNAPSHOT</version>
+    <version>0.8.3_compute_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-text/pom.xml
+++ b/magpie-policy-output-text/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-json_test-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-text/pom.xml
+++ b/magpie-policy-output-text/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.3_compute_noop-SNAPSHOT</version>
+    <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/magpie-policy-output-text/pom.xml
+++ b/magpie-policy-output-text/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magpie-parent</artifactId>
     <groupId>io.openraven.magpie</groupId>
-    <version>0.8.4-SNAPSHOT</version>
+    <version>0.8.4-json_test-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>io.openraven.magpie</groupId>
   <artifactId>magpie-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.8.3_diskless_logging-SNAPSHOT</version>
+  <version>0.8.3_compute_noop-SNAPSHOT</version>
   <name>Open Raven Magpie</name>
   <url>https://github.com/openraven/magpie</url>
   <description>Open Raven's Magpie Project</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>io.openraven.magpie</groupId>
   <artifactId>magpie-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.8.3_compute_noop-SNAPSHOT</version>
+  <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
   <name>Open Raven Magpie</name>
   <url>https://github.com/openraven/magpie</url>
   <description>Open Raven's Magpie Project</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>io.openraven.magpie</groupId>
   <artifactId>magpie-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.8.3_compute_partial_noop-SNAPSHOT</version>
+  <version>0.8.4-SNAPSHOT</version>
   <name>Open Raven Magpie</name>
   <url>https://github.com/openraven/magpie</url>
   <description>Open Raven's Magpie Project</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>io.openraven.magpie</groupId>
   <artifactId>magpie-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.8.4-json_test-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
   <name>Open Raven Magpie</name>
   <url>https://github.com/openraven/magpie</url>
   <description>Open Raven's Magpie Project</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>io.openraven.magpie</groupId>
   <artifactId>magpie-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.8.3_diskless-SNAPSHOT</version>
+  <version>0.8.3_diskless_logging-SNAPSHOT</version>
   <name>Open Raven Magpie</name>
   <url>https://github.com/openraven/magpie</url>
   <description>Open Raven's Magpie Project</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>io.openraven.magpie</groupId>
   <artifactId>magpie-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.8.4-SNAPSHOT</version>
+  <version>0.8.4-json_test-SNAPSHOT</version>
   <name>Open Raven Magpie</name>
   <url>https://github.com/openraven/magpie</url>
   <description>Open Raven's Magpie Project</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>io.openraven.magpie</groupId>
   <artifactId>magpie-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.8.3-SNAPSHOT</version>
+  <version>0.8.3_diskless-SNAPSHOT</version>
   <name>Open Raven Magpie</name>
   <url>https://github.com/openraven/magpie</url>
   <description>Open Raven's Magpie Project</description>


### PR DESCRIPTION
Proposed fix for PROD-8201 (GCP OOM) along with fixed assetIds for instances and disks.

This fix changes the way the `configuration` block is populated. Instead of using GSON to deserialize protobuf objects (and Jackson to reserialize to a JSON node), we utilize the `protobuf-java-util` library to convert the protobuf to to a JSON string, which is then reserialized by Jackson.

This fixes the OOM, but may affect the shape of the configuration block for most GCP assets. These changes do *not* include:
- BigQuery
- BigTable
- Dns
- IAM
- Projects
- Service Directories
- CloudSQL
- Storage

This also change the formatting of `assetIds` for Compute and Disk instances to match https://cloud.google.com/asset-inventory/docs/resource-name-format.