### PR TITLE
Fix: Fix the Dockerfile and the README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM openjdk:11.0.11-jre
-COPY magpie-cli/target/magpie*.tar.gz /
+FROM   maven:3.9.6-amazoncorretto-21-debian-bookworm as builder
+RUN mkdir /build/
+COPY ./ /build/ 
+RUN ls -al /build/
+RUN cd /build/ && mvn clean  install -DskipTests && mvn --projects magpie-cli assembly:single -DskipTests
+
+FROM openjdk:17.0.2-slim-bullseye
+COPY --from=builder /build/magpie-cli/target/*.tar.gz /tmp/
 RUN mkdir /magpie
-RUN tar -zxvf *.tar.gz --strip-components=1 -C magpie
+RUN tar -zxvf /tmp/*.tar.gz --strip-components=1 -C magpie
 WORKDIR /magpie
 CMD []
 ENTRYPOINT ["./magpie.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM openjdk:17.0.2-slim-bullseye
 COPY --from=builder /build/magpie-cli/target/*.tar.gz /tmp/
 RUN mkdir /magpie
 RUN tar -zxvf /tmp/*.tar.gz --strip-components=1 -C magpie
+RUN apt update && apt install -y git && apt clean all
 WORKDIR /magpie
 CMD []
 ENTRYPOINT ["./magpie.sh"]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ each layer may exist on separate compute instances.
 ```shell
 git clone git@github.com:openraven/magpie.git
 cd magpie
-mvn clean package install -DskipTests && mvn --projects magpie-cli assembly:single -DskipTests
+mvn clean install -DskipTests && mvn --projects magpie-cli assembly:single -DskipTests
 ```
 
 The distribution zip file will be located in `magpie-cli/target/magpie-<version>.zip`
@@ -63,7 +63,7 @@ the `uberjar` profile as such:
 
 ## Running Magpie
 
-*Java 11 is a prerequisite and must be installed to run Magpie.*
+*Java 17 is a prerequisite and must be installed to run Magpie.*
 
 Out of the box Magpie supports AWS for the cloud provider and outputs discovery data to `stdout` in JSON format. The
 AWS plugin utilizes the AWS Java SDK and will search for credentials as described in [Using Credentials](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+---
+version: "3.8"
+services:
+  magpie:
+    image: magpie:latest
+    entrypoint:
+      - /bin/bash
+      - -c
+      - sleep infinity
+    volumes:
+# PLEASE CHANGE THE PATH TO THE CONFIG FILE
+      - ./magpie-cli/src/assembly/files/config.yaml:/magpie/config.yaml
+  database:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: magpie
+      POSTGRES_USER: magpie
+      POSTGRES_DB: magpie


### PR DESCRIPTION
The versions used in the Dockerfile as well as the README.md didnt seems to be up to date.
I also add the build part for the Dockerfile. This would help to be independant from any previous java/maven installation on the the build host.

I also would like to state that i am not really a java developer and that i have changed the build process as it was failing probably due to a double goal .
Feel free to comment. 