### PR TITLE
595: Fix resource serialization

### DIFF
--- a/magpie-data/src/main/java/io/openraven/magpie/data/Resource.java
+++ b/magpie-data/src/main/java/io/openraven/magpie/data/Resource.java
@@ -23,9 +23,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import io.openraven.magpie.data.utils.EntityTypeResolver;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.PROPERTY, property = "resourceType")
+@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "resourceType")
 @JsonTypeIdResolver(EntityTypeResolver.class)
 public class Resource {
+
   public String resourceType;
 
   public String getResourceType() {

--- a/magpie-data/src/main/java/io/openraven/magpie/data/utils/EntityTypeResolver.java
+++ b/magpie-data/src/main/java/io/openraven/magpie/data/utils/EntityTypeResolver.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.DatabindContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import io.openraven.magpie.data.Resource;
 import io.openraven.magpie.data.exception.MissingEntityTypeException;
 import org.reflections.Reflections;
 
@@ -80,13 +81,16 @@ public class EntityTypeResolver extends TypeIdResolverBase {
     }
 
     @Override
-    public String idFromValue(Object o) {
-        return idFromValueAndType(o, o.getClass());
+    public String idFromValue(Object object) {
+      return idFromValueAndType(object, object.getClass());
     }
 
     @Override
-    public String idFromValueAndType(Object o, Class<?> aClass) {
-        return null;
+    public String idFromValueAndType(Object object, Class<?> aClass) {
+      if (object instanceof Resource) {
+        return ((Resource) object).getResourceType();
+      }
+      return aClass.getName();
     }
 
     @Override

--- a/magpie-data/src/test/java/io/openraven/magpie/data/aws/utils/EntityTypeResolverTest.java
+++ b/magpie-data/src/test/java/io/openraven/magpie/data/aws/utils/EntityTypeResolverTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.openraven.magpie.data.Resource;
 import io.openraven.magpie.data.aws.accounts.IamGroup;
+import io.openraven.magpie.data.aws.rds.RDSInstance;
 import io.openraven.magpie.data.gcp.container.ContainerAnalysisNote;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,18 @@ import org.junit.jupiter.api.Test;
 class EntityTypeResolverTest {
 
     public static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
+
+
+  @Test
+  void testResourceSerialization() throws JsonProcessingException {
+    RDSInstance rdsInstance = new RDSInstance();
+    String serialisedResource = MAPPER.writeValueAsString(rdsInstance);
+    String expectedJson = """
+    {"resourceType":"AWS::RDS::DBInstance","documentId":null,"arn":null,"resourceName":null,"resourceId":null,"awsRegion":null,"awsAccountId":null,"createdIso":null,"updatedIso":null,"discoverySessionId":null,"maxSizeInBytes":null,"sizeInBytes":null,"configuration":null,"supplementaryConfiguration":null,"tags":null,"discoveryMeta":null}\
+    """;
+    Assertions.assertEquals(expectedJson, serialisedResource);
+  }
+
 
     @Test
     public void testResolveAwsIamGroup() throws JsonProcessingException {


### PR DESCRIPTION
The `include = JsonTypeInfo.As.EXISTING_PROPERTY` configuration for `@JsonTypeInfo` in Jackson specifies how type information—used for polymorphic type handling—is included in the serialized JSON. Let's delve into what this specific configuration means and how it compares to other available options.

### `JsonTypeInfo.As.EXISTING_PROPERTY`

When you annotate a class with `@JsonTypeInfo` and use `include = JsonTypeInfo.As.EXISTING_PROPERTY`, Jackson is instructed to use an existing property on your Java object to include the type information necessary for deserialization. The `property` parameter of `@JsonTypeInfo` specifies the name of this property. This means:

- **During Serialization**: Jackson does not add any additional property for type information. Instead, it expects the type information to be part of an existing property in your serialized JSON.
- **During Deserialization**: Jackson looks at the specified property within the JSON to determine the type information necessary for instantiating the correct subclass.

This option is particularly useful when your JSON already contains a field that dictates the type but you don't want to introduce additional fields for type handling.

### Other `JsonTypeInfo.As` Configurations

Jackson provides several ways to include type information in your JSON, catering to different JSON structures and requirements:

1. **`PROPERTY`** (default): Adds type information as a separate property at the same level as other properties of the object. This is the most commonly used approach when you can modify the JSON structure to include type metadata.

2. **`WRAPPER_OBJECT`**: Wraps the serialized object in another JSON object where the field name is the type information, and the value is the original object. This is useful when you want to keep the JSON structure clean without mixing type information with actual data fields.

3. **`WRAPPER_ARRAY`**: Serializes the object into a JSON array where the first element is the type information and the second element is the actual object. Similar to `WRAPPER_OBJECT`, this keeps type information separate but uses an array structure.

4. **`EXTERNAL_PROPERTY`**: Puts the type information in an external property, typically at the same level as the serialized object. This is useful in cases where you have a JSON object with multiple fields needing polymorphic type handling and you want to centralize the type information.

5. **`EXISTING_PROPERTY`**: As described, expects the type information to be part of an existing property in the serialized JSON, avoiding the addition of extra fields for type handling.

Each of these configurations serves different use cases depending on how you wish to structure your JSON and manage type information for polymorphism. The choice depends on your specific requirements for serialization and deserialization, as well as the structure of your JSON data.